### PR TITLE
chore: add github templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,48 @@
+---
+name: '🐛 Bug Report'
+about: Did things not work as expected?
+title: "fix: [what is the issue?] in [where is the issue?]"
+labels: 'status:triage'
+---
+
+<!---
+Thanks for filing an issue 😄 ! Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have reported the same issue before.
+-->
+
+# 🐛 Bug Report
+
+<!--- Provide a general summary of the issue here -->
+
+## 💻 Repro or Code Sample
+
+<!-- Please provide steps to reproduce the issue and/or a code repository, gist, code snippet or sample files -->
+
+## 🤔 Expected Behavior
+
+<!--- Tell us what should happen -->
+
+## 😯 Current Behavior
+
+<!--- Tell us what happens instead of the expected behavior -->
+<!--- If you are seeing an error, please include the full error message and stack trace -->
+<!--- If applicable, provide screenshots -->
+
+## 💁 Possible Solution
+
+<!--- Not obligatory, but suggest a fix/reason for the bug -->
+<!--- Please let us know if you'd be willing to contribute the fix; we'd be happy to work with you -->
+
+## 🔦 Context
+
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## 🌍 Your Environment
+
+<!--- Include as many relevant details as possible about the environment you experienced the bug in -->
+
+* OS & Device: [e.g. MacOS, iOS, Windows, Linux] on [iPhone 7, PC]
+* Browser [e.g. Microsoft Edge, Google Chrome, Apple Safari, Mozilla FireFox]
+* .NET and FAST Version [e.g. 1.8.0]

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,20 @@
+---
+name: 📚 Documentation
+about: Find an inaccuracy in the documentation or something missing?
+title: "docs: fix/add [what] to/in [where]"
+labels: 'status:triage'
+---
+
+<!---
+Thanks for filing an issue 😄 ! Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have reported the same issue before.
+-->
+
+# 🙋 Documentation Request
+
+<!--- Provide a general summary of what is missing or incorrect in the documentation -->
+
+## 💁 Possible Solution
+
+<!--- Not obligatory, but feel free to suggest a content outline for larger topics -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,40 @@
+---
+name: 🙋 Feature Request
+about: Want us to add something?
+title: "feat: add [what] to/in [where]"
+labels: 'status:triage'
+---
+
+<!---
+Thanks for filing an issue 😄 ! Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have requested the same feature before.
+-->
+
+# 🙋 Feature Request
+
+<!--- Provide a general summary of the feature here -->
+
+## 🤔 Expected Behavior
+
+<!--- Tell us how the feature should work -->
+
+## 😯 Current Behavior
+
+<!--- Explain how the feature would alter/enhance current behavior -->
+
+## 💁 Possible Solution
+
+<!--- Ideas how to implement this feature -->
+<!--- What implementation solution would be ideal for you? -->
+
+## 🔦 Context
+
+<!--- What are you trying to accomplish? -->
+<!--- How has not having this feature affected you? -->
+<!--- What alternatives have you considered? -->
+
+## 💻 Examples
+
+<!-- Examples help us understand the requested feature better -->
+<!-- Attach screenshots or images if they would add detail to your request -->

--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -1,0 +1,27 @@
+---
+name: 💬 Request For Comment (RFC)
+about: Want comments from the team and community on your proposal?
+title: "rfc: add [what] to/in [where]"
+labels: 'status:triage'
+---
+
+<!---
+Thanks for filing an issue 😄 ! Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have created a similar RFC before.
+-->
+
+# 💬 RFC
+
+<!--- Provide a detailed summary of the feature here -->
+
+## 🔦 Context
+
+<!--- What are you trying to accomplish? How has not having this feature affected you? -->
+<!--- What alternatives have you considered? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## 💻 Examples
+
+<!-- Examples help us understand the requested feature better -->
+<!-- Attach screenshots or images if they would add detail to your request -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,63 @@
+<!---
+Thanks for filing a pull request 😄 ! Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have pushed the same thing before!
+
+Provide a summary of your changes in the title field above.
+-->
+
+# Pull Request
+
+## 📖 Description
+
+<!---
+Provide some background and a description of your work.
+What problem does this change solve?
+Is this a breaking change, chore, fix, feature, etc?
+-->
+
+### 🎫 Issues
+
+<!---
+* List and link relevant issues here.
+-->
+
+## 👩‍💻 Reviewer Notes
+
+<!---
+Provide some notes for reviewers to help them provide targeted feedback and testing.
+
+Do you recommend a smoke test for this PR? What steps should be followed?
+Are there particular areas of the code the reviewer should focus on?
+-->
+
+## 📑 Test Plan
+
+<!---
+Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
+-->
+
+## ✅ Checklist
+
+### General
+
+<!--- Review the list and put an x in the boxes that apply. -->
+
+- [ ] I have added tests for my changes.
+- [ ] I have tested my changes.
+- [ ] I have updated the project documentation to reflect my changes.
+- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
+
+### Component-specific
+
+<!--- Review the list and put an x in the boxes that apply. -->
+<!--- Remove this section if not applicable. -->
+
+- [ ] I have added a new component
+- [ ] I have modified an existing component
+
+## ⏭ Next Steps
+
+<!---
+If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
+-->


### PR DESCRIPTION
This PR adds some standard templates for issues and PRs so that the community has a better experience interacting through GitHub. These are based on what we've got in the main FAST repo.