### PR TITLE
fix radio group example input binding type

### DIFF
--- a/examples/FluentUIServerSample/Components/FluentRadioGroupTest.razor
+++ b/examples/FluentUIServerSample/Components/FluentRadioGroupTest.razor
@@ -41,7 +41,7 @@
 <div role="toolbar" style="display: flex; flex-direction: column; margin-top: 12px;">
     <div style="display: flex; flex-direction: row; align-items: stretch; width: 100%;">
         <button style="width: 40px; margin-right: 4px;">go</button>
-        <FluentRadioGroup required="true" Name="navigation">
+        <FluentRadioGroup Required="true" Name="navigation">
             <FluentRadio Value="back">back</FluentRadio>
             <FluentRadio Value="forward">forward</FluentRadio>
             <FluentRadio Value="refresh">refresh</FluentRadio>


### PR DESCRIPTION
# Pull Request

## 📖 Description
The input type of Required is type bool. This caused the example to fail to load at runtime.
The previous binding was a binding the the string whose text was "true". This change updates it to use the bool value true.

### 🎫 Issues

NA

## 👩‍💻 Reviewer Notes
## 📑 Test Plan
## ✅ Checklist

### General
- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [ ] I have modified an existing component

## ⏭ Next Steps

The Tabs example has a similar issue that I'll submit a PR for as well.