### PR TITLE
Add <FluentDesignSystemProvider> wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,22 @@ Next, add a script tag to your index or main layout to reference the web compone
 
 > **Note:** If the script reference is added to a `.razor` or `.cshtml` file, you will need to escape the `@` with a second `@` like so `https://unpkg.com/@@fluentui/web-components`.
 
-With the dependencies added, you must next enable the Fluent Design System itself by wrapping your HTML with a `fluent-design-system-provider` element. Here's an example of what that might look like:
+With the dependencies added, you must next enable the Fluent Design System itself by wrapping your HTML with a `<FluentDesignSystemProvider>` component. A good place to do this is in the `App.razor` file.  Here's an example of what that might look like:
 
-```html
-<body>
-    <fluent-design-system-provider use-defaults>
-        <component type="typeof(App)" render-mode="ServerPrerendered" />
-        <script src="_framework/blazor.server.js"></script>
-    </fluent-design-system-provider>
-</body>
+```
+<FluentDesignSystemProvider>
+    <Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
+        <Found Context="routeData">
+            <RouteView RouteData="@routeData" />
+        </Found>
+        <NotFound>
+            <p>Sorry, there's nothing at this address.</p>
+        </NotFound>
+    </Router>
+</FluentDesignSystemProvider>
 ```
 
-While you can have multiple design system providers, the most common configuration is to have a single provider that wraps your entire application. You'll likely also want to add the `use-defaults` attribute, to ensure that the default settings for FluentUI are applied.
+While you can have multiple design system providers, the most common configuration is to have a single provider that wraps your entire application. The code above does exactely that. The component ensures that the default settings for FluentUI are applied (by adding the `use-defaults` attribute in the output). An example of using an additional design system provider (with extra attributes) can be found in the `FluentUIServerSample` in the file `Webcomponents.razor` 
 
 Once these steps are completed, you can then begin using the components throughout your Blazor application. Take a look in the `examples` folder of this repository to see how to use the various components.
 

--- a/examples/FluentUIServerSample/App.razor
+++ b/examples/FluentUIServerSample/App.razor
@@ -1,8 +1,10 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" />
-    </Found>
-    <NotFound>        
-        <p>Sorry, there's nothing at this address.</p>
-    </NotFound>
-</Router>
+﻿<FluentDesignSystemProvider>
+    <Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
+        <Found Context="routeData">
+            <RouteView RouteData="@routeData" />
+        </Found>
+        <NotFound>
+            <p>Sorry, there's nothing at this address.</p>
+        </NotFound>
+    </Router>
+</FluentDesignSystemProvider>

--- a/examples/FluentUIServerSample/Pages/Webcomponents.razor
+++ b/examples/FluentUIServerSample/Pages/Webcomponents.razor
@@ -1,7 +1,7 @@
 @page "/webcomponents/{Target?}"
 @using FluentUIServerSample.Components
 <div class="main">
-  <fluent-design-system-provider role="navigation" class="navigation" background-color="#E5E5E5">
+  <FluentDesignSystemProvider role="navigation" class="navigation" background-color="#E5E5E5">
     <h1 class="head">Fluent components test page</h1>
       <ul>
           <li>
@@ -98,7 +98,7 @@
               <FluentAnchor href="webcomponents/TreeView" Appearance="@(@Target == "TreeView" ? Appearance.Neutral : Appearance.Stealth)">Tree View</FluentAnchor>
           </li>
       </ul>
-  </fluent-design-system-provider>
+  </FluentDesignSystemProvider>
   <div class="content">
   @switch(Target)
   {

--- a/examples/FluentUIServerSample/Pages/_Host.cshtml
+++ b/examples/FluentUIServerSample/Pages/_Host.cshtml
@@ -10,15 +10,13 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script type="module" src="https://unpkg.com/@@fluentui/web-components"></script>
     <link rel="stylesheet" href="~/site.css" />
     <title>FluentUIServerSample</title>
     <base href="~/" />
 </head>
 <body>
-    <fluent-design-system-provider use-defaults>
-        <component type="typeof(App)" render-mode="ServerPrerendered" />
-        <script src="_framework/blazor.server.js"></script>
-    </fluent-design-system-provider>
+    <component type="typeof(App)" render-mode="ServerPrerendered" />
+    <script src="_framework/blazor.server.js"></script>
+    <script type="module" src="https://unpkg.com/@@fluentui/web-components"></script>
 </body>
 </html>

--- a/src/Microsoft.Fast.Components.FluentUI/FluentDesignSystemProvider.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/FluentDesignSystemProvider.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.Fast.Components.FluentUI
+{
+    public class FluentDesignSystemProvider : ComponentBase
+    {
+        [Parameter] public RenderFragment? ChildContent { get; set; }
+        [Parameter(CaptureUnmatchedValues = true)]
+        public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
+        /// <inheritdoc />
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenElement(0, "fluent-design-system-provider");
+
+            if (AdditionalAttributes == null || AdditionalAttributes.Count == 0)
+                builder.AddAttribute(1, "use-defaults");
+            else
+                builder.AddMultipleAttributes(1, AdditionalAttributes);
+
+            builder.AddContent(2, ChildContent);
+            builder.CloseElement();
+
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR adds a `<FluentDesignSystemProvider>` component that wraps the `<fluent-design-system-provider>`. Documentation has been added to the readme file. The component is added to the `FluentUIServerSample` for testing and example usage  

## 👩‍💻 Reviewer Notes
This component was created to deliver a more Blazor-like experience when adding this library to a project. The component is added to the `App.razor` file to fulfill the general HTML wrapping requirement. `App.razor` is a more logical place in a Blazor project to do this than `_Host.cshtml` (or `index.html` in a WebAssemply app). 
When no attributes are supplied, the component automatically adds the `use-defaults` attribute. When attributes are supplied, these are outputted in the element and the `use-defaults` is omitted

## 📑 Test Plan
Run the `FluentUIServerSample`. Inspect html to see that`<fluent-design-system-provider>` is inserted in the right place and with the right settings. 
Navigate to the Webcomponents page and inspect HTML to see additional `<fluent-design-system-provider>` with other attributes is inserted.

## ✅ Checklist

### General
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [x] I have added a new component
- [ ] I have modified an existing component

## ⏭ Next Steps
No next steps needed.