### PR TITLE
FluentTextField changes and additions

### DIFF
--- a/examples/FluentUIServerSample/Components/FluentTextFieldTest.razor
+++ b/examples/FluentUIServerSample/Components/FluentTextFieldTest.razor
@@ -82,3 +82,21 @@
 <!-- With aria-label -->
 <h4>With aria-label</h4>
 <FluentTextField aria-label="Text field with aria-label"></FluentTextField>
+
+<h4>Password</h4>
+<FluentTextField TextFieldType="TextFieldType.Password">Password</FluentTextField>
+
+<h4>Email (with spellcheck)</h4>
+<FluentTextField TextFieldType="TextFieldType.Email" Spellcheck="true">Email (with spellcheck)</FluentTextField>
+
+<h4>Telephone number</h4>
+<FluentTextField TextFieldType="TextFieldType.Tel">Telephone</FluentTextField>
+
+<h4>Url</h4>
+<FluentTextField TextFieldType="TextFieldType.Url">Url</FluentTextField>
+
+<h4>Minlength</h4>
+<FluentTextField MinLength="4">Minlength</FluentTextField>
+
+<h4>Maxlength</h4>
+<FluentTextField MaxLength="4">Maxlength</FluentTextField>

--- a/src/Microsoft.Fast.Components.FluentUI/Components/FluentTextField.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/FluentTextField.razor
@@ -1,5 +1,20 @@
 @inherits FluentInputBase<string>
-<fluent-text-field autofocus="@Autofocus" appearance="@Appearance.ToAttributeValue()" value="@BindConverter.FormatValue(CurrentValue)" @onchange="@(EventCallback.Factory.CreateBinder<string>(this, __value => CurrentValueAsString = __value, CurrentValueAsString))" readonly="@Readonly" disabled="@Disabled" required="@Required" placeholder="@Placeholder" @attributes="AdditionalAttributes">@ChildContent</fluent-text-field>
+<fluent-text-field autofocus="@Autofocus"
+                   appearance="@Appearance.ToAttributeValue()"
+                   value="@BindConverter.FormatValue(CurrentValue)"
+                   @onchange="@(EventCallback.Factory.CreateBinder<string>(this, __value => CurrentValueAsString = __value, CurrentValueAsString))"
+                   type="@TextFieldType.ToAttributeValue()"
+                   size="@Size"
+                   minlength="@MinLength"
+                   maxlength="@MaxLength"
+                   spellcheck="@Spellcheck"
+                   readonly="@Readonly"
+                   disabled="@Disabled"
+                   required="@Required"
+                   placeholder="@Placeholder"
+                   @attributes="AdditionalAttributes">
+    @ChildContent
+</fluent-text-field>
 @code{
     [Parameter] public bool? Disabled { get; set; }
 
@@ -9,11 +24,22 @@
 
     [Parameter] public bool? Autofocus { get; set; }
 
-    [Parameter] public Resize? Resize { get; set; }
+    [Parameter] public int? Size { get; set; }
 
     [Parameter] public Appearance? Appearance { get; set; }
 
+    [Parameter] public TextFieldType? TextFieldType { get; set; }
+
     [Parameter] public string Placeholder { get; set; }
+
+    [Parameter] public int? MinLength { get; set; }
+
+    [Parameter] public int? MaxLength { get; set; }
+
+    [Parameter] public bool? Spellcheck { get; set; }
+
+    //Pattern
+    //List
 
     [Parameter] public RenderFragment ChildContent { get; set; }
 

--- a/src/Microsoft.Fast.Components.FluentUI/TextFieldType.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/TextFieldType.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Fast.Components.FluentUI
+{
+    public enum TextFieldType
+    {
+        Text,
+        Email,
+        Password,
+        Tel,
+        Url
+    }
+
+    internal static class TextFieldTypeExtensions
+    {
+        private static Dictionary<TextFieldType, string> _textFieldTypeValues =
+            Enum.GetValues<TextFieldType>().ToDictionary(id => id, id => Enum.GetName(id).ToLowerInvariant());
+
+        public static string ToAttributeValue(this TextFieldType? value) => value == null ? null : _textFieldTypeValues[value.Value];
+    }
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description
Additions and changes to the FluentTextField component. 
- Rename parameter `Resize`  to `Size`. As per https://github.com/microsoft/fast/blob/master/packages/web-components/fast-foundation/src/text-field/text-field.spec.md a `FluentTextField` does not contain a `Resize` parameter (of type Resize?) but does contain a `Size` parameter (of type int?)

Add new parameters:
- MinLength (int?); the minimum number of characters long the input can be and still be considered valid
- MaxLength (int?);  the maximum number of characters the input should accept
- TextFieldType (TextFieldType? enum (text, email, password, tel, url))
- Spellcheck (bool?);controls whether or not to enable spell checking for the input field, or if the default spell checking configuration should be used 


## 👩‍💻 Reviewer Notes
Look at `FluentTextField.razor` for implementation of parameters, `TextFieldType.cs` for enum and `FluentTextFieldTest.razor` for testing the new parameters

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

