### PR TITLE
fix: darkMode already declared on certain component test pages

### DIFF
--- a/examples/FluentUIServerSample/Components/FluentSwitchTest.razor
+++ b/examples/FluentUIServerSample/Components/FluentSwitchTest.razor
@@ -6,7 +6,7 @@
           grid-gap: 12px;
       ">
     <script suppress-error='BL9992'>
-      let darkTheme = false;
+      darkTheme = false;
     </script>
     <FluentSwitch onclick="document.dir = document.dir === 'rtl' ? 'ltr' : 'rtl'; document.getElementsByTagName('fluent-design-system-provider')[0].setAttribute('direction', document.dir);">
         <span style="padding-inline-end: 8px;">Direction</span>

--- a/examples/FluentUIServerSample/Components/FluentTreeItemTest.razor
+++ b/examples/FluentUIServerSample/Components/FluentTreeItemTest.razor
@@ -6,7 +6,7 @@
           grid-gap: 12px;
       ">
     <script suppress-error='BL9992'>
-      let darkTheme = false;
+      darkTheme = false;
     </script>
     <FluentSwitch onclick="document.dir = document.dir === 'rtl' ? 'ltr' : 'rtl'; document.getElementsByTagName('fluent-design-system-provider')[0].setAttribute('direction', document.dir);">
         <span style="padding-inline-end: 8px;">Direction</span>

--- a/examples/FluentUIServerSample/Components/FluentTreeViewTest.razor
+++ b/examples/FluentUIServerSample/Components/FluentTreeViewTest.razor
@@ -6,7 +6,7 @@
           grid-gap: 12px;
       ">
     <script suppress-error='BL9992'>
-      let darkTheme = false;
+      darkTheme = false;
     </script>
     <FluentSwitch onclick="document.dir = document.dir === 'rtl' ? 'ltr' : 'rtl'; document.getElementsByTagName('fluent-design-system-provider')[0].setAttribute('direction', document.dir);">
         <span style="padding-inline-end: 8px;">Direction</span>


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

Fixed a bug where `Identifier 'darkTheme' has already been declared` was being thrown on the following components on the `Web Components` sample page:
- Switch
- Tree Item
- Tree View

### 🎫 Issues

#37 

## 👩‍💻 Reviewer Notes

The script doesn't actually need to be there as the darkMode toggle sets it to true when it's undefined. However, setting false beforehand gives more clarity when understanding where the "darkMode setting/variable" comes from.

## 📑 Test Plan

On the `Web Components` sample page the following should not throw a 'declaration' error:
- Switch
- Tree Item
- Tree View

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->