### PR TITLE
Added sorting/filtering demo to FluentDataGrid, added HeaderCellTemplate to component

### DIFF
--- a/examples/FluentUIServerSample/Components/FluentDataGridTest.razor
+++ b/examples/FluentUIServerSample/Components/FluentDataGridTest.razor
@@ -34,6 +34,21 @@
     </FluentDataGridRow>
 </FluentDataGrid>
 
+<h2>Sorting/Filtering grid</h2>
+<FluentTextField @oninput="FilterChanged">Filter Fruit</FluentTextField>
+<FluentDataGrid id="sortingGrid" GridTemplateColumns="1fr 1fr 1fr 1fr" RowsData=SortedRowsGrid ColumnDefinitions=SortingColumnsGrid>
+    <HeaderCellTemplate >
+        <FluentButton @onclick=@(()=>SortColumn(context))>
+            @context.Title 
+            @if (context.Title == lastSortColumn?.Title)
+            {
+                @(isAscending ? " ↑" : " ↓")                
+            }
+        </FluentButton>
+    </HeaderCellTemplate>
+</FluentDataGrid>
+
+
 @code {
 
     public class SampleGrid1Data
@@ -49,9 +64,14 @@
     }
 
     public record SampleGrid2Data(string Item1, string Item2, string Item3, string Item4);
+    public record SampleGrid3Data(string fruit, string cost, string color);
 
     public List<ColumnDefinition<SampleGrid1Data>> ColumnsGrid1 = new List<ColumnDefinition<SampleGrid1Data>>();
     public List<ColumnDefinition<SampleGrid2Data>> ColumnsGrid2 = new List<ColumnDefinition<SampleGrid2Data>>();
+    public List<ColumnDefinition<SampleGrid3Data>> SortingColumnsGrid = new List<ColumnDefinition<SampleGrid3Data>>();
+    private ColumnDefinition<SampleGrid3Data>? lastSortColumn = null;
+    private bool isAscending = false;
+    public string filterValue = "";
 
     List<SampleGrid1Data> RowsGrid1 = new List<SampleGrid1Data>()
     {
@@ -67,6 +87,17 @@
         new SampleGrid2Data("value 1-4", "value 2-4", "value 3-4", "value 4-4" )
 
     };
+        
+    List<SampleGrid3Data> RawSortedRowsGrid = new List<SampleGrid3Data>()
+    {
+        new SampleGrid3Data("apples", "$1.50", "red" ),
+        new SampleGrid3Data("bananas", "$0.99", "yellow" ),
+        new SampleGrid3Data("grapes", "$1.99", "purple" ),
+        new SampleGrid3Data("oranges", "$1.25", "orange" )
+
+    };
+    List<SampleGrid3Data> SortedRowsGrid;
+
 
     protected override void OnInitialized()
     {
@@ -78,6 +109,66 @@
         ColumnsGrid2.Add(new ColumnDefinition<SampleGrid2Data>("Item 3", x => x.Item3));
         ColumnsGrid2.Add(new ColumnDefinition<SampleGrid2Data>("Item 4", x => x.Item4));
 
+        SortingColumnsGrid.Add(new ColumnDefinition<SampleGrid3Data>("Fruit", x => x.fruit));
+        SortingColumnsGrid.Add(new ColumnDefinition<SampleGrid3Data>("Cost", x => x.cost));
+        SortingColumnsGrid.Add(new ColumnDefinition<SampleGrid3Data>("Color", x => x.color));
+        
+        SortedRowsGrid = RawSortedRowsGrid;
+
         base.OnInitialized();
+    }
+
+    private void FilterChanged(ChangeEventArgs args)
+    {
+        var filter = args.Value as string;
+        
+        if (string.IsNullOrWhiteSpace(filter))
+        {
+            SortedRowsGrid = RawSortedRowsGrid;
+        }
+        else
+        {
+            SortedRowsGrid = RawSortedRowsGrid.Where(x => x.fruit.Contains(filter)).ToList();
+        }
+        if (lastSortColumn != null)
+        {
+            SortedRowsGrid.Sort(new CustomComparer(lastSortColumn.FieldSelector, isAscending));
+        }
+        
+    }
+
+    private void SortColumn(ColumnDefinition<SampleGrid3Data> columnDefinition)
+    {
+        if (lastSortColumn?.Title == columnDefinition.Title)
+        {
+            isAscending = !isAscending;
+        }
+        else
+        {
+            lastSortColumn = columnDefinition;
+            isAscending = true;
+        }
+        SortedRowsGrid.Sort(new CustomComparer(columnDefinition.FieldSelector, isAscending));
+    }
+
+    class CustomComparer : IComparer<SampleGrid3Data>
+    {
+        Func<SampleGrid3Data, object> _selector;
+        bool _isAscending;
+
+        public CustomComparer(Func<SampleGrid3Data, object> selector, bool isAscending)
+        {
+            _selector = selector;
+            _isAscending = isAscending;
+        }
+
+        int IComparer<SampleGrid3Data>.Compare(SampleGrid3Data x, SampleGrid3Data y)
+        {
+            var xs = _selector(x) as string;
+            var ys = _selector(y) as string;
+            if (xs == null || ys == null)
+                return 0;
+            return string.Compare(xs, ys) * (_isAscending ? 1 : -1);
+        }
     }
 }

--- a/src/Microsoft.Fast.Components.FluentUI/Components/FluentDataGrid.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/FluentDataGrid.razor
@@ -13,7 +13,16 @@
                 int gridColumn = 1;
                 foreach (ColumnDefinition<TItem> column in ColumnDefinitions)
                 {
-                    <FluentDataGridCell GridColumn=@(gridColumn++) CellType=DataGridCellType.ColumnHeader>@column.Title</FluentDataGridCell>
+                    <FluentDataGridCell GridColumn=@(gridColumn++) CellType=DataGridCellType.ColumnHeader>
+                    @if (HeaderCellTemplate != null)
+                    {
+                        @HeaderCellTemplate(column)
+                    }
+                    else
+                    {
+                        @column.Title
+                    }
+                    </FluentDataGridCell>
                 }
             }
         </FluentDataGridRow>
@@ -56,6 +65,9 @@
     [Parameter]
     public IEnumerable<ColumnDefinition<TItem>> ColumnDefinitions { get; set; }
 
+    [Parameter]
+    public RenderFragment<ColumnDefinition<TItem>>? HeaderCellTemplate { get; set; } = null;
+  
     [Parameter]
     public RenderFragment<TItem>? RowItemTemplate { get; set; } = null;
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

@vnbaaij created the nice `FluentDataGrid` component for blazor and I wanted to get up to speed on how these FAST components translated into Blazor components, so I decided to add the filtering and sorting demo to the data-grid.  It uses basic techniques like `Sort` with `IComparer` and LINQ based filtering with a simple `Where` clause. 

I was forced to add an additional parameter to `FluentDataGrid` called `HeaderCellTemplate` because there seemed to be no way to modify the header without creating the cells manually, too.  I decided to have the `HeaderCellTemplate` callback parameter be the entire `ColumnDefinition<TItem>` object so that one can use both the FieldSelector and the header title.

### 🎫 Issues

Seems to work fine!

## 👩‍💻 Reviewer Notes



## 📑 Test Plan


## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [X] I have modified an existing component

## ⏭ Next Steps

Virtualization testing?