### PR TITLE
fix the access to ListboxOptionPage

### DIFF
--- a/examples/FluentUI.Demo.Shared/Pages/ListboxOptionPage.razor
+++ b/examples/FluentUI.Demo.Shared/Pages/ListboxOptionPage.razor
@@ -2,29 +2,43 @@
 <h1>Option</h1>
 
 <h2>Defaults</h2>
-<FluentOption>
-    Text content is the value when the value attribute is absent.
-</FluentOption>
+<FluentSelect>
+	<FluentOption>
+		Text content is the value when the value attribute is absent.
+	</FluentOption>
+</FluentSelect>
 
-<FluentOption Value="Value content loses">
-    Even when the value attribute and text are both present, this text should be displayed.
-</FluentOption>
+<FluentSelect>
+	<FluentOption Value="Value content loses">
+		Even when the value attribute and text are both present, this text should be displayed.
+	</FluentOption>
+</FluentSelect>
 
-<FluentOption Value="This option has no text content."></FluentOption>
+<FluentSelect>
+	<FluentOption Value="This option has no text content."></FluentOption>
+</FluentSelect>
 
 <h2>Disabled</h2>
-<FluentOption Disabled="true">This option is disabled.</FluentOption>
+<FluentSelect>
+	<FluentOption Disabled="true">This option is disabled.</FluentOption>
+	<FluentOption>Only this option can be selected</FluentOption>
+</FluentSelect>
 
 <h2>Selected</h2>
-<FluentOption Selected="true">This option is selected by default.</FluentOption>
+<FluentSelect>
+	<FluentOption>Option 1</FluentOption>
+	<FluentOption Selected="true">This option is selected by default.</FluentOption>
+</FluentSelect>
 
 <h2>Slots</h2>
-<FluentOption Value="1">
-    <svg slot="start" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-        <path d="M6.5 7.7h-1v-1h1v1zm4.1 0h-1v-1h1v1zm4.1-1v2.1h-1v2.6l-.1.6-.3.5c-.1.1-.3.3-.5.3l-.6.1H10l-3.5 3v-3H3.9l-.6-.1-.5-.3c-.1-.1-.3-.3-.3-.5l-.1-.6V8.8h-1V6.7h1V5.2l.1-.6.3-.5c.1-.1.3-.3.5-.3l.6-.1h3.6V1.9a.8.8 0 01-.4-.4L7 1V.6l.2-.3.3-.2L8 0l.4.1.3.2.3.3V1l-.1.5-.4.4v1.7h3.6l.6.1.5.3c.1.1.3.3.3.5l.1.6v1.5h1.1zm-2.1-1.5l-.2-.4-.4-.2H3.9l-.4.2-.1.4v6.2l.2.4.4.2h3.6v1.8L9.7 12h2.5l.4-.2.2-.4V5.2zM5.8 8.9l1 .7 1.2.2a5 5 0 001.2-.2l1-.7.7.7c-.4.4-.8.7-1.4.9-.5.2-1 .3-1.6.3s-1.1-.1-1.6-.3A3 3 0 015 9.6l.8-.7z" />
-    </svg>
-    <svg slot="end" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-        <path d="M6.5 7.7h-1v-1h1v1zm4.1 0h-1v-1h1v1zm4.1-1v2.1h-1v2.6l-.1.6-.3.5c-.1.1-.3.3-.5.3l-.6.1H10l-3.5 3v-3H3.9l-.6-.1-.5-.3c-.1-.1-.3-.3-.3-.5l-.1-.6V8.8h-1V6.7h1V5.2l.1-.6.3-.5c.1-.1.3-.3.5-.3l.6-.1h3.6V1.9a.8.8 0 01-.4-.4L7 1V.6l.2-.3.3-.2L8 0l.4.1.3.2.3.3V1l-.1.5-.4.4v1.7h3.6l.6.1.5.3c.1.1.3.3.3.5l.1.6v1.5h1.1zm-2.1-1.5l-.2-.4-.4-.2H3.9l-.4.2-.1.4v6.2l.2.4.4.2h3.6v1.8L9.7 12h2.5l.4-.2.2-.4V5.2zM5.8 8.9l1 .7 1.2.2a5 5 0 001.2-.2l1-.7.7.7c-.4.4-.8.7-1.4.9-.5.2-1 .3-1.6.3s-1.1-.1-1.6-.3A3 3 0 015 9.6l.8-.7z" />
-    </svg>
-    This option has an icon in its start and end slots.
-</FluentOption>
+<FluentSelect>
+	<FluentOption Value="1">
+		<svg slot="start" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+			<path d="M6.5 7.7h-1v-1h1v1zm4.1 0h-1v-1h1v1zm4.1-1v2.1h-1v2.6l-.1.6-.3.5c-.1.1-.3.3-.5.3l-.6.1H10l-3.5 3v-3H3.9l-.6-.1-.5-.3c-.1-.1-.3-.3-.3-.5l-.1-.6V8.8h-1V6.7h1V5.2l.1-.6.3-.5c.1-.1.3-.3.5-.3l.6-.1h3.6V1.9a.8.8 0 01-.4-.4L7 1V.6l.2-.3.3-.2L8 0l.4.1.3.2.3.3V1l-.1.5-.4.4v1.7h3.6l.6.1.5.3c.1.1.3.3.3.5l.1.6v1.5h1.1zm-2.1-1.5l-.2-.4-.4-.2H3.9l-.4.2-.1.4v6.2l.2.4.4.2h3.6v1.8L9.7 12h2.5l.4-.2.2-.4V5.2zM5.8 8.9l1 .7 1.2.2a5 5 0 001.2-.2l1-.7.7.7c-.4.4-.8.7-1.4.9-.5.2-1 .3-1.6.3s-1.1-.1-1.6-.3A3 3 0 015 9.6l.8-.7z" />
+		</svg>
+		<svg slot="end" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+			<path d="M6.5 7.7h-1v-1h1v1zm4.1 0h-1v-1h1v1zm4.1-1v2.1h-1v2.6l-.1.6-.3.5c-.1.1-.3.3-.5.3l-.6.1H10l-3.5 3v-3H3.9l-.6-.1-.5-.3c-.1-.1-.3-.3-.3-.5l-.1-.6V8.8h-1V6.7h1V5.2l.1-.6.3-.5c.1-.1.3-.3.5-.3l.6-.1h3.6V1.9a.8.8 0 01-.4-.4L7 1V.6l.2-.3.3-.2L8 0l.4.1.3.2.3.3V1l-.1.5-.4.4v1.7h3.6l.6.1.5.3c.1.1.3.3.3.5l.1.6v1.5h1.1zm-2.1-1.5l-.2-.4-.4-.2H3.9l-.4.2-.1.4v6.2l.2.4.4.2h3.6v1.8L9.7 12h2.5l.4-.2.2-.4V5.2zM5.8 8.9l1 .7 1.2.2a5 5 0 001.2-.2l1-.7.7.7c-.4.4-.8.7-1.4.9-.5.2-1 .3-1.6.3s-1.1-.1-1.6-.3A3 3 0 015 9.6l.8-.7z" />
+		</svg>
+		This option has an icon in its start and end slots.
+	</FluentOption>
+</FluentSelect>


### PR DESCRIPTION


# Pull Request
## 📖 Description

I was testing the sample and I noticed that the page `ListBoxOption` was crashing. this is due to the component FluentOption should have an ancestor FluentSelect, FluentListBox or FluentComboBox, so I wraped all of the `FluentOption` into different `FluentSelect`

### 🎫 Issues

--

## 👩‍💻 Reviewer Notes



## 📑 Test Plan

Nothing really, I just ran the code and went into the sample page


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component

## ⏭ Next Steps

I noticed that the option `Selected="true"` for a default value is not working, neither it does in FluentListBox or FluentComboBox; 
example:

```csharp
<FluentSelect>
	<FluentOption>Option 1</FluentOption>
	<FluentOption Selected="true">This option is selected by default.</FluentOption>
</FluentSelect>
```
It does have `Option 1` as default one. 

I couldnt see any issue created but at the same time I am not sure if you guys have track of issues in your project in MS or jsut here in github. I did not created it because of that reason.