### PR TITLE
chore (workflow) - Avoid running workflows for markdown

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -3,9 +3,13 @@ name: Validate
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:


### PR DESCRIPTION
With `paths-ignore` set to `**.md` we can avoid running workflow for PR if there is just documentation file edited (markdown) and ultimately can save resources. 