### PR TITLE
(Bug Fix) Base Layer Luminance was culture related

### DIFF
--- a/examples/FluentUI.Demo.Shared/Shared/MainLayout.razor.cs
+++ b/examples/FluentUI.Demo.Shared/Shared/MainLayout.razor.cs
@@ -22,7 +22,7 @@ namespace FluentUI.Demo.Shared
 
         public void SwitchTheme()
         {
-            baseLayerLuminance = baseLayerLuminance == 0 ? 1 : 0;
+            baseLayerLuminance = baseLayerLuminance == 0.2f ? 1 : 0.2f;
         }
 
         protected override void OnParametersSet()

--- a/src/Microsoft.Fast.Components.FluentUI/Components/FluentDesignSystemProvider.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/FluentDesignSystemProvider.razor
@@ -59,7 +59,7 @@
     neutral-stroke-hover-delta="@NeutralStrokeHoverDelta"
     neutral-stroke-active-delta="@NeutralStrokeActiveDelta"
     neutral-stroke-focus-delta="@NeutralStrokeFocusDelta"
-    base-layer-luminance="@BaseLayerLuminance"
+    base-layer-luminance="@BaseLayerLuminance?.ToString(System.Globalization.CultureInfo.InvariantCulture)"
     @attributes="AdditionalAttributes"
 >
 @ChildContent


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

The BaseLayerLuminance parameter in the FluentDesignSystemProvider was a culture related float value, which leads to the problem that browsers with a region that uses comma instead of dot for float/double values set the value with comma instead of dot in the html tag.
This leads to unexpected colours in Component.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

Open the example page on a browser which is set to a region which uses comma instead of dot float/double values (German for example) and trigger the Light / Dark Toggle (I have set it from 0 to 0.2 to test it)!

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component