### PR TITLE
Changed the IconService to only set the HttpClient.BaseAddress if it …

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI/IconService.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/IconService.cs
@@ -11,7 +11,7 @@ public class IconService
     {
         HttpClient = httpClient;
         NavigationManager = navigationManager;
-        HttpClient.BaseAddress = new Uri(NavigationManager.BaseUri);
+        HttpClient.BaseAddress ??= new Uri(NavigationManager.BaseUri);
     }
 
 }


### PR DESCRIPTION
…doesn't have one.



# Pull Request

## 📖 Description

Updated the `IconService` to only update the `HttpClient.BaseAddress` if it didn't have one.

### 🎫 Issues

`HttpClient.BaseAddress` was being set in the `IconService` constructor because standalone testing of a Blazor client app (not hosted) or a server app, didn't always see one being set.  In this same testing the `HttpClient` had not been used yet so it was ok to set (or potentially reset) this property.

If a hosted (or probably any model Blazor app) that gets data, may have used the `HttpClient` before the `IconService` is constructed, at which time the setting of the `HttpClient.BaseAddress` failed as it can only be set before the `HttpClient` is used.

## 👩‍💻 Reviewer Notes

Simple fix was to utilize the null-coalescing operator.


## 📑 Test Plan

Non, all exiting test should still pass, and any new test involving using the `HttpClient` before the `IconService` should now also pass.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->