### PR TITLE
Fluent anchor bUnit tests

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Accordion/FluentAccordionItemShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Accordion/FluentAccordionItemShould.cs
@@ -1,7 +1,7 @@
 using Bunit;
 using Xunit;
 
-namespace Microsoft.Fast.Components.FluentUI.Tests.FluentAccordion
+namespace Microsoft.Fast.Components.FluentUI.Tests.Accordion
 {
     public class FluentAccordionItemShould : TestBase
     {

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Accordion/FluentAccordionShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Accordion/FluentAccordionShould.cs
@@ -1,7 +1,7 @@
 using Bunit;
 using Xunit;
 
-namespace Microsoft.Fast.Components.FluentUI.Tests.FluentAccordion
+namespace Microsoft.Fast.Components.FluentUI.Tests.Accordion
 {
     public class FluentAccordionShould : TestBase
     {

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Anchor/FluentAnchorRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Anchor/FluentAnchorRenderShould.cs
@@ -5,6 +5,23 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Anchor
 {
     public class FluentAnchorRenderShould : TestBase
     {
+        [Fact]
+        public void RenderProperly_AttributesDefaultValues()
+        {
+            // Arrange
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "appearance=\"neutral\"> " +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+        
         [Theory]
         [InlineData("")]
         [InlineData("something")]
@@ -213,25 +230,6 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Anchor
             cut.MarkupMatches("<fluent-anchor " +
                               "href=\"https://fast.design\" " +
                               $"appearance=\"{appearance.ToAttributeValue()}\"> " +
-                              "click me!" +
-                              "</fluent-anchor>");
-        }
-
-        [Fact]
-        public void RenderProperly_AppearanceAttribute_Default()
-        {
-            // Arrange
-            TestContext.JSInterop.SetupModule(
-                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
-            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
-                parameters => parameters
-                    .Add(p => p.Href, "https://fast.design")
-                    .AddChildContent("click me!"));
-
-            // Assert
-            cut.MarkupMatches("<fluent-anchor " +
-                              "href=\"https://fast.design\" " +
-                              "appearance=\"neutral\"> " +
                               "click me!" +
                               "</fluent-anchor>");
         }

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Anchor/FluentAnchorRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Anchor/FluentAnchorRenderShould.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Anchor
                               "click me!" +
                               "</fluent-anchor>");
         }
-        
+
         [Theory]
         [InlineData("https://fast.design")]
         [InlineData("/something/something")]
@@ -235,7 +235,7 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Anchor
                               "click me!" +
                               "</fluent-anchor>");
         }
-        
+
         [Fact]
         public void RenderProperly_Without_ChildContent()
         {
@@ -286,6 +286,56 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Anchor
                               "href=\"https://fast.design\" " +
                               "style=\"background-color: black;\" " +
                               "appearance=\"neutral\"> " +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Fact]
+        public void RenderProperly_WithASingleAdditionalAttribute()
+        {
+            // Arrange & Act
+            string additionalAttributeName = "additional";
+            string additionalAttributeValue = "additional-value";
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Href, "https://fast.design")
+                    .AddUnmatched(additionalAttributeName, additionalAttributeValue)
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              "appearance=\"neutral\" " +
+                              $"{additionalAttributeName}=\"{additionalAttributeValue}\"> " +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Fact]
+        public void RenderProperly_WithMultipleAdditionalAttributes()
+        {
+            // Arrange & Act
+            string additionalAttribute1Name = "additional1";
+            string additionalAttribute1Value = "additional1-value";
+            string additionalAttribute2Name = "additional2";
+            string additionalAttribute2Value = "additional2-value";
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Href, "https://fast.design")
+                    .AddUnmatched(additionalAttribute1Name, additionalAttribute1Value)
+                    .AddUnmatched(additionalAttribute2Name, additionalAttribute2Value)
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              "appearance=\"neutral\" " +
+                              $"{additionalAttribute1Name}=\"{additionalAttribute1Value}\" " +
+                              $"{additionalAttribute2Name}=\"{additionalAttribute2Value}\"> " +
                               "click me!" +
                               "</fluent-anchor>");
         }

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Anchor/FluentAnchorRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Anchor/FluentAnchorRenderShould.cs
@@ -1,7 +1,7 @@
 using Bunit;
 using Xunit;
 
-namespace Microsoft.Fast.Components.FluentUI.Tests.FluentAnchor
+namespace Microsoft.Fast.Components.FluentUI.Tests.Anchor
 {
     public class FluentAnchorRenderShould : TestBase
     {

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Anchor/FluentAnchorRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Anchor/FluentAnchorRenderShould.cs
@@ -235,6 +235,18 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Anchor
                               "click me!" +
                               "</fluent-anchor>");
         }
+        
+        [Fact]
+        public void RenderProperly_Without_ChildContent()
+        {
+            // Arrange
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>();
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor appearance=\"neutral\"></fluent-anchor>");
+        }
 
         [Fact]
         public void RenderProperly_WithAdditionalCSSClass()

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/AnchoredRegion/FluentAnchoredRegionShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/AnchoredRegion/FluentAnchoredRegionShould.cs
@@ -1,0 +1,573 @@
+using Bunit;
+using Xunit;
+
+namespace Microsoft.Fast.Components.FluentUI.Tests.AnchoredRegion
+{
+    public class FluentAnchoredRegionShould : TestBase
+    {
+        [Fact]
+        public void RenderProperly_AttributeDefaultValues()
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters.AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+        
+        [Fact]
+        public void RenderProperly_AnchorAttribute()
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.Anchor, "anchor-id")
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "anchor=\"anchor-id\" " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_ViewportAttribute()
+        {
+            // Arrange && Act
+            string content = "content";
+            string viewPortValue = "viewport-value";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.Viewport, viewPortValue)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              $"viewport=\"{viewPortValue}\" " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Theory]
+        [InlineData(AxisPositioningMode.Dynamic)]
+        [InlineData(AxisPositioningMode.Locktodefault)]
+        [InlineData(AxisPositioningMode.Uncontrolled)]
+        public void RenderProperly_HorizontalPositioningAttribute(AxisPositioningMode axisPositioningMode)
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.HorizontalPositioningMode, axisPositioningMode)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              $"horizontal-positioning-mode=\"{axisPositioningMode.ToAttributeValue()}\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Theory]
+        [InlineData(HorizontalPosition.End)]
+        [InlineData(HorizontalPosition.Left)]
+        [InlineData(HorizontalPosition.Right)]
+        [InlineData(HorizontalPosition.Start)]
+        [InlineData(HorizontalPosition.Unset)]
+        public void RenderProperly_HorizontalDefaultPositionAttribute(HorizontalPosition horizontalPosition)
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.HorizontalDefaultPosition, horizontalPosition)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              $"horizontal-default-position=\"{horizontalPosition.ToAttributeValue()}\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_HorizontalViewportLockAttribute()
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.HorizontalViewportLock, true)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-viewport-lock=\"\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_HorizontalInsetAttribute()
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.HorizontalInset, true)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-inset=\"\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_HorizontalThresholdAttribute()
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.HorizontalThreshold, 10)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"10\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Theory]
+        [InlineData(AxisScalingMode.Anchor)]
+        [InlineData(AxisScalingMode.Content)]
+        [InlineData(AxisScalingMode.Fill)]
+        public void RenderProperly_HorizontalScalingAttribute(AxisScalingMode axisScalingMode)
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.HorizontalScaling, axisScalingMode)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              $"horizontal-scaling=\"{axisScalingMode.ToAttributeValue()}\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Theory]
+        [InlineData(AxisPositioningMode.Dynamic)]
+        [InlineData(AxisPositioningMode.Locktodefault)]
+        [InlineData(AxisPositioningMode.Uncontrolled)]
+        public void RenderProperly_VerticalPositioningModeAttribute(AxisPositioningMode axisPositioningMode)
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.VerticalPositioningMode, axisPositioningMode)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              $"vertical-positioning-mode=\"{axisPositioningMode.ToAttributeValue()}\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Theory]
+        [InlineData(VerticalPosition.Unset)]
+        [InlineData(VerticalPosition.Bottom)]
+        [InlineData(VerticalPosition.Top)]
+        public void RenderProperly_VerticalDefaultPositionAttribute(VerticalPosition verticalPosition)
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.VerticalDefaultPosition, verticalPosition)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              $"vertical-default-position=\"{verticalPosition.ToAttributeValue()}\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_VerticalViewportLockAttribute()
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.VerticalViewportLock, true)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-viewport-lock=\"\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_VerticalInsetAttribute()
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.VerticalInset, true)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-inset=\"\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_VerticalThresholdAttribute()
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.VerticalThreshold, 100)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"100\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Theory]
+        [InlineData(AxisScalingMode.Content)]
+        [InlineData(AxisScalingMode.Anchor)]
+        [InlineData(AxisScalingMode.Fill)]
+        public void RenderProperly_VerticalScalingAttribute(AxisScalingMode axisScalingMode)
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.VerticalScaling, axisScalingMode)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              $"vertical-scaling=\"{axisScalingMode.ToAttributeValue()}\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_FixedPlacementAttribute()
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.FixedPlacement, true)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\" " +
+                              "fixed-placement=\"\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Theory]
+        [InlineData(AutoUpdateMode.Auto)]
+        [InlineData(AutoUpdateMode.Anchor)]
+        public void RenderProperly_AutoUpdateModeAttribute(AutoUpdateMode autoUpdateMode)
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.AutoUpdateMode, autoUpdateMode)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              $"auto-update-mode=\"{autoUpdateMode.ToAttributeValue()}\" >" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_WithAdditionalCSSClass()
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.Class, "additional-css-class")
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "class=\"additional-css-class\" " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_WithAdditionalStyle()
+        {
+            // Arrange && Act
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .Add(p => p.Style, "background-color: black;")
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              "style=\"background-color: black;\" " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_WithASingleAdditionalAttribute()
+        {
+            // Arrange && Act
+            string additionalAttributeName = "additional";
+            string additionalAttributeValue = "additional-value";
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .AddUnmatched(additionalAttributeName, additionalAttributeValue)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              $"{additionalAttributeName}=\"{additionalAttributeValue}\" " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+
+        [Fact]
+        public void RenderProperly_WithMultipleAdditionalAttribute()
+        {
+            // Arrange && Act
+            string additionalAttribute1Name = "additional1";
+            string additionalAttribute1Value = "additional1-value";
+            string additionalAttribute2Name = "additional2";
+            string additionalAttribute2Value = "additional2-value";
+            string content = "content";
+            IRenderedComponent<FluentAnchoredRegion> cut = TestContext.RenderComponent<FluentAnchoredRegion>(
+                parameters => parameters
+                    .AddUnmatched(additionalAttribute1Name, additionalAttribute1Value)
+                    .AddUnmatched(additionalAttribute2Name, additionalAttribute2Value)
+                    .AddChildContent(content));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchored-region " +
+                              $"{additionalAttribute1Name}=\"{additionalAttribute1Value}\" " +
+                              $"{additionalAttribute2Name}=\"{additionalAttribute2Value}\" " +
+                              "horizontal-positioning-mode=\"uncontrolled\" " +
+                              "horizontal-default-position=\"unset\" " +
+                              "horizontal-threshold=\"0\" " +
+                              "horizontal-scaling=\"content\" " +
+                              "vertical-positioning-mode=\"uncontrolled\" " +
+                              "vertical-default-position=\"unset\" " +
+                              "vertical-threshold=\"0\" " +
+                              "vertical-scaling=\"content\" " +
+                              "auto-update-mode=\"anchor\">" +
+                              $"{content}" +
+                              "</fluent-anchored-region>");
+        }
+    }
+}

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/FluentAnchor/FluentAnchorRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/FluentAnchor/FluentAnchorRenderShould.cs
@@ -1,0 +1,281 @@
+using Bunit;
+using Xunit;
+
+namespace Microsoft.Fast.Components.FluentUI.Tests.FluentAnchor
+{
+    public class FluentAnchorRenderShould : TestBase
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("something")]
+        public void RenderProperly_DownloadAttribute(string download)
+        {
+            // Arrange && Act
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Href, "https://fast.design")
+                    .Add(p => p.Download, download)
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "appearance=\"neutral\" " +
+                              "href=\"https://fast.design\" " +
+                              $"download=\"{download}\">" +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+        
+        [Theory]
+        [InlineData("https://fast.design")]
+        [InlineData("/something/something")]
+        [InlineData("#/something/something")]
+        public void RenderProperly_HrefAttribute(string url)
+        {
+            // Arrange && Act
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Href, url)
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "appearance=\"neutral\" " +
+                              $"href=\"{url}\">" +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Theory]
+        [InlineData("en-GB")]
+        [InlineData("fr")]
+        public void RenderProperly_HrefLangAttribute(string lang)
+        {
+            // Arrange
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Hreflang, lang)
+                    .Add(p => p.Href, "https://fast.design")
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              "appearance=\"neutral\" " +
+                              $"hreflang=\"{lang}\">" +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Theory]
+        [InlineData("https://fast.design")]
+        [InlineData("https://fast.design https://google.com")]
+        public void RenderProperly_PingAttribute(string ping)
+        {
+            // Arrange
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Ping, ping)
+                    .Add(p => p.Href, "https://fast.design")
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              "appearance=\"neutral\" " +
+                              $"ping=\"{ping}\">" +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Theory]
+        [InlineData("no-referrer")]
+        [InlineData("no-referrer-when-downgrade")]
+        public void RenderProperly_ReferrerPolicyAttribute(string referrerPolicy)
+        {
+            // Arrange
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Referrerpolicy, referrerPolicy)
+                    .Add(p => p.Href, "https://fast.design")
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              "appearance=\"neutral\" " +
+                              $"referrerPolicy=\"{referrerPolicy}\">" +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Theory]
+        [InlineData("alternate")]
+        [InlineData("bookmark")]
+        public void RenderProperly_RelAttribute(string rel)
+        {
+            // Arrange
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Rel, rel)
+                    .Add(p => p.Href, "https://fast.design")
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              "appearance=\"neutral\" " +
+                              $"rel=\"{rel}\">" +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Theory]
+        [InlineData("_blank")]
+        [InlineData("_self")]
+        [InlineData("_parent")]
+        [InlineData("_top")]
+        public void RenderProperly_TargetAttribute(string target)
+        {
+            // Arrange
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Target, target)
+                    .Add(p => p.Href, "https://fast.design")
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              "appearance=\"neutral\" " +
+                              $"target=\"{target}\">" +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Theory]
+        [InlineData("image/png")]
+        [InlineData("application/pdf")]
+        public void RenderProperly_TypeAttribute(string type)
+        {
+            // Arrange
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Type, type)
+                    .Add(p => p.Href, "https://fast.design")
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              "appearance=\"neutral\" " +
+                              $"type=\"{type}\"> " +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Theory]
+        [InlineData(Appearance.Accent)]
+        [InlineData(Appearance.Filled)]
+        [InlineData(Appearance.Hypertext)]
+        [InlineData(Appearance.Outline)]
+        [InlineData(Appearance.Lightweight)]
+        [InlineData(Appearance.Neutral)]
+        [InlineData(Appearance.Stealth)]
+        public void RenderProperly_AppearanceAttribute(Appearance appearance)
+        {
+            // Arrange
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Appearance, appearance)
+                    .Add(p => p.Href, "https://fast.design")
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              $"appearance=\"{appearance.ToAttributeValue()}\"> " +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Fact]
+        public void RenderProperly_AppearanceAttribute_Default()
+        {
+            // Arrange
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Href, "https://fast.design")
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              "appearance=\"neutral\"> " +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Fact]
+        public void RenderProperly_WithAdditionalCSSClass()
+        {
+            // Arrange & Act
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Href, "https://fast.design")
+                    .Add(p => p.Class, "additional-class")
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              "class=\"additional-class\" " +
+                              "appearance=\"neutral\"> " +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+
+        [Fact]
+        public void RenderProperly_WithAdditionalStyle()
+        {
+            // Arrange & Act
+            TestContext.JSInterop.SetupModule(
+                "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
+            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                parameters => parameters
+                    .Add(p => p.Href, "https://fast.design")
+                    .Add(p => p.Style, "background-color: black;")
+                    .AddChildContent("click me!"));
+
+            // Assert
+            cut.MarkupMatches("<fluent-anchor " +
+                              "href=\"https://fast.design\" " +
+                              "style=\"background-color: black;\" " +
+                              "appearance=\"neutral\"> " +
+                              "click me!" +
+                              "</fluent-anchor>");
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description
- chore
- bUnit tests agains FluentAnchor and FluentAnchoredRegion components
- directory rename, so the test directories reflects on the components' directory names

### 🎫 Issues
- no related issue

## 👩‍💻 Reviewer Notes

- these tests cover only if the rendered HTML is good or not
- A test class covers a single component
- a test covering the default value case where the component attributes are not set up. This case ensures that if there is a change in the default values of the attributes we will be informed
- tests covering the generated HTML when attributes are set up
  - where the input is an enum I created a Theory and all the enum values are exercised (probably overkill, but worth to try how painful manage this way and I do not expect changing these enums frequently)
  - the capabilities provided by base class also covered in these test classes, possible it is overkill. My attitude here is that, we offer these capabilities at every component, so we should be absolutely sure 1, they are available, 2, they are working fine. If turns out that the maintenance cost of these tests are high I'll remove them.
- FluentAnchor has a click prevention functionality provided by the JS code, this click prevention is not tested here 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->