### PR TITLE
tests: Fluent badge bunit tests

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Accordion/FluentAccordionItemRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Accordion/FluentAccordionItemRenderShould.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Microsoft.Fast.Components.FluentUI.Tests.Accordion
 {
-    public class FluentAccordionItemShould : TestBase
+    public class FluentAccordionItemRenderShould : TestBase
     {
         [Fact]
         public void RenderProperly_WithChildContent_IsNull()

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Accordion/FluentAccordionRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Accordion/FluentAccordionRenderShould.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Microsoft.Fast.Components.FluentUI.Tests.Accordion
 {
-    public class FluentAccordionShould : TestBase
+    public class FluentAccordionRenderShould : TestBase
     {
         [Fact]
         public void RenderProperly_When_ChildContent_IsNull()

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/AnchoredRegion/FluentAnchoredRegionRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/AnchoredRegion/FluentAnchoredRegionRenderShould.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Microsoft.Fast.Components.FluentUI.Tests.AnchoredRegion
 {
-    public class FluentAnchoredRegionShould : TestBase
+    public class FluentAnchoredRegionRenderShould : TestBase
     {
         [Fact]
         public void RenderProperly_AttributeDefaultValues()

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/AnchoredRegion/FluentAnchoredRegionRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/AnchoredRegion/FluentAnchoredRegionRenderShould.cs
@@ -511,7 +511,7 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.AnchoredRegion
         }
 
         [Fact]
-        public void RenderProperly_WithASingleAdditionalAttribute()
+        public void RenderProperly_WithAnAdditionalAttribute()
         {
             // Arrange && Act
             string additionalAttributeName = "additional";
@@ -539,7 +539,7 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.AnchoredRegion
         }
 
         [Fact]
-        public void RenderProperly_WithMultipleAdditionalAttribute()
+        public void RenderProperly_WithMultipleAdditionalAttributes()
         {
             // Arrange && Act
             string additionalAttribute1Name = "additional1";

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Badge/FluentBadgeRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Badge/FluentBadgeRenderShould.cs
@@ -1,0 +1,195 @@
+using Bunit;
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.Fast.Components.FluentUI.Tests.Badge
+{
+    public class FluentBadgeRenderShould : TestBase
+    {
+        
+        [Fact]
+        public void RenderProperly_DefaultAttributes()
+        {
+            // Arrange && Act
+            IRenderedComponent<FluentBadge> cut = TestContext.RenderComponent<FluentBadge>(
+                parameters => parameters
+                    .AddChildContent("childcontent"));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-badge " +
+                              "appearance=\"accent\">" +
+                              "childcontent" +
+                              "</fluent-badge>");
+        }
+        
+        [Theory]
+        [InlineData(Appearance.Neutral)]
+        [InlineData(Appearance.Accent)]
+        [InlineData(Appearance.Lightweight)]
+        public void RenderProperly_AppearanceAttribute(Appearance appearance)
+        {
+            // Arrange && Act
+            IRenderedComponent<FluentBadge> cut = TestContext.RenderComponent<FluentBadge>(
+                parameters => parameters
+                    .Add(p => p.Appearance, appearance)
+                    .AddChildContent("childcontent"));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-badge " +
+                              $"appearance=\"{appearance.ToAttributeValue()}\">" +
+                              "childcontent" +
+                              "</fluent-badge>");
+        }
+        
+        [Theory]
+        [InlineData(Appearance.Filled)]
+        [InlineData(Appearance.Hypertext)]
+        [InlineData(Appearance.Outline)]
+        [InlineData(Appearance.Stealth)]
+        public void ThrowArgumentException_When_AppearanceAttributeValue_IsInvalid(Appearance appearance)
+        {
+            // Arrange && Act
+            Action action = () =>
+            {
+                TestContext.RenderComponent<FluentBadge>(
+                    parameters => parameters
+                        .Add(p => p.Appearance, appearance)
+                        .AddChildContent("childcontent"));
+            };
+
+            // Assert
+            action.Should().ThrowExactly<ArgumentException>();
+        }
+        
+        [Fact]
+        public void RenderProperly_FillAttribute()
+        {
+            // Arrange && Act
+            string backgroundColor = "red";
+            IRenderedComponent<FluentBadge> cut = TestContext.RenderComponent<FluentBadge>(
+                parameters => parameters
+                    .Add(p => p.Fill, backgroundColor)
+                    .AddChildContent("childcontent"));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-badge " +
+                              "appearance=\"accent\" " +
+                              $"fill=\"{backgroundColor}\">" +
+                              "childcontent" +
+                              "</fluent-badge>");
+        }
+        
+        [Fact]
+        public void RenderProperly_ColorAttribute()
+        {
+            // Arrange && Act
+            string color = "red";
+            IRenderedComponent<FluentBadge> cut = TestContext.RenderComponent<FluentBadge>(
+                parameters => parameters
+                    .Add(p => p.Color, color)
+                    .AddChildContent("childcontent"));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-badge " +
+                              "appearance=\"accent\" " +
+                              $"color=\"{color}\">" +
+                              "childcontent" +
+                              "</fluent-badge>");
+        }
+        
+        [Fact]
+        public void RenderProperly_CircularAttribute()
+        {
+            // Arrange && Act
+            IRenderedComponent<FluentBadge> cut = TestContext.RenderComponent<FluentBadge>(
+                parameters => parameters
+                    .Add(p => p.Circular, true)
+                    .AddChildContent("childcontent"));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-badge " +
+                              "appearance=\"accent\" " +
+                              "circular=\"\">" +
+                              "childcontent" +
+                              "</fluent-badge>");
+        }
+        
+        [Fact]
+        public void RenderProperly_WithAdditionalCssClass()
+        {
+            // Arrange && Act
+            string cssClass = "additional_class";
+            IRenderedComponent<FluentBadge> cut = TestContext.RenderComponent<FluentBadge>(
+                parameters => parameters
+                    .Add(p => p.Class, cssClass)
+                    .AddChildContent("childcontent"));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-badge " +
+                              $"class=\"{cssClass}\" " +
+                              "appearance=\"accent\">" +
+                              "childcontent" +
+                              "</fluent-badge>");
+        }
+
+        [Fact]
+        public void RenderProperly_WithAdditionalStyle()
+        {
+            // Arrange && Act
+            string style = "background-color:red; width:100px;";
+            IRenderedComponent<FluentBadge> cut = TestContext.RenderComponent<FluentBadge>(
+                parameters => parameters
+                    .Add(p => p.Style, style)
+                    .AddChildContent("childcontent"));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-badge " +
+                              $"style=\"{style}\" " +
+                              "appearance=\"accent\">" +
+                              "childcontent" +
+                              "</fluent-badge>");
+        }
+
+        [Fact]
+        public void RenderProperly_WithAnAdditionalAttribute()
+        {
+            // Arrange && Act
+            string additionalAttributeName = "additional-attribute-name";
+            string additionalAttributeValue = "additional-attribute-value";
+            IRenderedComponent<FluentBadge> cut = TestContext.RenderComponent<FluentBadge>(
+                parameters => parameters
+                    .AddUnmatched(additionalAttributeName, additionalAttributeValue)
+                    .AddChildContent("childcontent"));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-badge " +
+                              "appearance=\"accent\" " +
+                              $"{additionalAttributeName}=\"{additionalAttributeValue}\">" +
+                              "childcontent" +
+                              "</fluent-badge>");
+        }
+
+        [Fact]
+        public void RenderProperly_WithMultipleAdditionalAttributes()
+        {
+            // Arrange && Act
+            string additionalAttribute1Name = "additional-attribute1-name";
+            string additionalAttribute1Value = "additional-attribute1-value";
+            string additionalAttribute2Name = "additional-attribute2-name";
+            string additionalAttribute2Value = "additional-attribute2-value";
+            IRenderedComponent<FluentBadge> cut = TestContext.RenderComponent<FluentBadge>(
+                parameters => parameters
+                    .AddUnmatched(additionalAttribute1Name, additionalAttribute1Value)
+                    .AddUnmatched(additionalAttribute2Name, additionalAttribute2Value)
+                    .AddChildContent("childcontent"));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-badge " +
+                              "appearance=\"accent\" " +
+                              $"{additionalAttribute1Name}=\"{additionalAttribute1Value}\" " +
+                              $"{additionalAttribute2Name}=\"{additionalAttribute2Value}\">" +
+                              "childcontent" +
+                              "</fluent-badge>");
+        }
+    }
+}

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Microsoft.Fast.Components.FluentUI.Tests.csproj
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Microsoft.Fast.Components.FluentUI.Tests.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="bunit" Version="1.13.5" />
+        <PackageReference Include="FluentAssertions" Version="6.8.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
@@ -21,10 +22,6 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Microsoft.Fast.Components.FluentUI\Microsoft.Fast.Components.FluentUI.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Badge" />
     </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Microsoft.Fast.Components.FluentUI.Tests.csproj
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Microsoft.Fast.Components.FluentUI.Tests.csproj
@@ -23,4 +23,8 @@
       <ProjectReference Include="..\Microsoft.Fast.Components.FluentUI\Microsoft.Fast.Components.FluentUI.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="Badge" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
# Pull Request

## 📖 Description

bUnit tests covering FluentBadge component rendering, meaning we check if the HTML is valid generated by the Blazor component.

### 🎫 Issues
No related issues.

## 👩‍💻 Reviewer Notes

- I renamed previous tests files as they didn't have "Render" in their name
- the additional functionalities (dealing with extra style, css class and unmatched attributes) are exercised at component level
- Appearance input value is checked as the enum contains more value than the component supports (the enum itself is widely used across the components)
- I took the liberty and added FluentAssertions nuget package. I don't know what is the policy when it comes to an additional 3rd party package. If this package cannot be added, please let me know. I'll remove it and assert the exception in a different way.

## 📑 Test Plan

Testing is not necessary here.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->