### PR TITLE
FluentButton and FluentCalendar tests

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Button/ButtonRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Button/ButtonRenderShould.cs
@@ -1,0 +1,525 @@
+using Bunit;
+using Xunit;
+
+namespace Microsoft.Fast.Components.FluentUI.Tests.Button
+{
+    public class ButtonRenderShould : TestBase
+    {
+        [Fact]
+        public void RenderProperly_Default()
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              "appearance=\"neutral\"> " +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+
+        [Fact]
+        public void RenderProperly_AutofocusAttribute()
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Autofocus, true)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              "appearance=\"neutral\" " +
+                              "autofocus=\"\"> " +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+
+        [Theory]
+        [InlineData("form-id-attribute")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void RenderProperly_FormIdAttribute(string? formId)
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.FormId, formId)
+                    .AddChildContent(childContent));
+
+            // Assert
+            if (formId is not null)
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\" " +
+                                  $"form=\"{formId}\"> " +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+            else
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\">" +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+        }
+
+        [Theory]
+        [InlineData("submit")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void RenderProperly_FormActionAttribute(string? formAction)
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Action, formAction)
+                    .AddChildContent(childContent));
+
+            // Assert
+            if (formAction is not null)
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\" " +
+                                  $"formaction=\"{formAction}\"> " +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+            else
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\">" +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+        }
+
+        [Theory]
+        [InlineData("multipart/form-data")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void RenderProperly_FormEnctypeAttribute(string? formEnctype)
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Enctype, formEnctype)
+                    .AddChildContent(childContent));
+
+            // Assert
+            if (formEnctype is not null)
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\" " +
+                                  $"formenctype=\"{formEnctype}\"> " +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+            else
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\">" +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+        }
+
+        [Theory]
+        [InlineData("post")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void RenderProperly_FormMethodAttribute(string? formMethod)
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Method, formMethod)
+                    .AddChildContent(childContent));
+
+            // Assert
+            if (formMethod is not null)
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\" " +
+                                  $"formmethod=\"{formMethod}\"> " +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+            else
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\">" +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+        }
+
+        [Fact]
+        public void RenderProperly_FormNovalidateAttribute()
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.NoValidate, true)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              "appearance=\"neutral\" " +
+                              "formnovalidate=\"\"> " +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+
+        [Theory]
+        [InlineData("_self")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void RenderProperly_FormTargetAttribute(string? formTarget)
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Target, formTarget)
+                    .AddChildContent(childContent));
+
+            // Assert
+            if (formTarget is not null)
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\" " +
+                                  $"formtarget=\"{formTarget}\"> " +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+            else
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\">" +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+        }
+
+        [Theory]
+        [InlineData(ButtonType.Button)]
+        [InlineData(ButtonType.Reset)]
+        [InlineData(ButtonType.Submit)]
+        public void RenderProperly_TypeAttribute(ButtonType buttonType)
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Type, buttonType)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              $"type=\"{buttonType.ToAttributeValue()}\" " +
+                              "appearance=\"neutral\">" +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+
+        [Theory]
+        [InlineData("id-value")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void RenderProperly_IdAttribute(string? id)
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Id, id)
+                    .AddChildContent(childContent));
+
+            // Assert
+            if (id is not null)
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  $"id=\"{id}\" " +
+                                  "appearance=\"neutral\">" +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+            else
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\">" +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+        }
+
+        [Theory]
+        [InlineData("some-value")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void RenderProperly_ValueAttribute(string? value)
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Value, value)
+                    .AddChildContent(childContent));
+
+            // Assert
+            if (value is not null)
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  $"value=\"{value}\" " +
+                                  "appearance=\"neutral\">" +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+            else
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\">" +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+        }
+
+        [Theory]
+        [InlineData("some-value")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void RenderProperly_CurrentValueAttribute(string? currentValue)
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.CurrentValue, currentValue)
+                    .AddChildContent(childContent));
+
+            // Assert
+            if (currentValue is not null)
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  $"current-value=\"{currentValue}\" " +
+                                  "appearance=\"neutral\">" +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+            else
+            {
+                cut.MarkupMatches("<fluent-button " +
+                                  "type=\"button\" " +
+                                  "appearance=\"neutral\">" +
+                                  $"{childContent}" +
+                                  "</fluent-button>");
+            }
+        }
+
+        [Fact]
+        public void RenderProperly_DisabledAttribute()
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Disabled, true)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              "disabled=\"\"" +
+                              "appearance=\"neutral\">" +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+
+        [Fact]
+        public void RenderProperly_NameAttribute()
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            string name = "name-value";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Name, name)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              $"name=\"{name}\" " +
+                              "appearance=\"neutral\">" +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+
+        [Fact]
+        public void RenderProperly_RequiredAttribute()
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Required, true)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              "required=\"\" " +
+                              "appearance=\"neutral\">" +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+
+        [Theory]
+        [InlineData(Appearance.Accent)]
+        [InlineData(Appearance.Filled)]
+        [InlineData(Appearance.Hypertext)]
+        [InlineData(Appearance.Lightweight)]
+        [InlineData(Appearance.Neutral)]
+        [InlineData(Appearance.Outline)]
+        [InlineData(Appearance.Stealth)]
+        public void RenderProperly_AppearanceAttribute(Appearance appearance)
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Appearance, appearance)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              $"appearance=\"{appearance.ToAttributeValue()}\">" +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+
+        [Fact]
+        public void RenderProperly_ClassAttribute()
+        {
+            // Arrange && Act
+            string className = "additional-class";
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Class, className)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              "appearance=\"neutral\" " +
+                              $"class=\"{className}\">" +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+
+        [Fact]
+        public void RenderProperly_StyleAttribute()
+        {
+            // Arrange && Act
+            string style = "background-color: green;";
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .Add(p => p.Style, style)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              "appearance=\"neutral\" " +
+                              $"style=\"{style}\">" +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+
+        [Fact]
+        public void RenderProperly_AdditionalAttribute()
+        {
+            // Arrange && Act
+            string additionalAttribute1Name = "additional-attribute1-name";
+            string additionalAttribute1Value = "additional-attribute1-value";
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .AddUnmatched(additionalAttribute1Name, additionalAttribute1Value)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              "appearance=\"neutral\" " +
+                              $"{additionalAttribute1Name}=\"{additionalAttribute1Value}\">" +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+
+        [Fact]
+        public void RenderProperly_AdditionalAttributes()
+        {
+            // Arrange && Act
+            string additionalAttribute1Name = "additional-attribute1-name";
+            string additionalAttribute1Value = "additional-attribute1-value";
+            string additionalAttribute2Name = "additional-attribute2-name";
+            string additionalAttribute2Value = "additional-attribute2-value";
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = TestContext.RenderComponent<FluentButton>(
+                parameters => parameters
+                    .AddUnmatched(additionalAttribute1Name, additionalAttribute1Value)
+                    .AddUnmatched(additionalAttribute2Name, additionalAttribute2Value)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              "appearance=\"neutral\" " +
+                              $"{additionalAttribute1Name}=\"{additionalAttribute1Value}\" " +
+                              $"{additionalAttribute2Name}=\"{additionalAttribute2Value}\">" +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+    }
+}

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Button/ButtonRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Button/ButtonRenderShould.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using FluentAssertions;
 using Xunit;
 
 namespace Microsoft.Fast.Components.FluentUI.Tests.Button
@@ -198,9 +199,10 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Button
 
         [Theory]
         [InlineData("_self")]
-        [InlineData(null)]
+        [InlineData("_blank")]
+        [InlineData("_parent")]
+        [InlineData("_top")]
         [InlineData("")]
-        [InlineData(" ")]
         public void RenderProperly_FormTargetAttribute(string? formTarget)
         {
             // Arrange && Act
@@ -211,23 +213,39 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Button
                     .AddChildContent(childContent));
 
             // Assert
-            if (formTarget is not null)
+            cut.MarkupMatches("<fluent-button " +
+                              "type=\"button\" " +
+                              "appearance=\"neutral\" " +
+                              $"formtarget=\"{formTarget}\"> " +
+                              $"{childContent}" +
+                              "</fluent-button>");
+        }
+        
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("_funky")]
+        public void Throw_ArgumentException_When_FormTargetAttribute_IsInvalid(string? formTarget)
+        {
+            // Arrange && Act
+            string childContent = "fluent-button";
+            IRenderedComponent<FluentButton> cut = null;
+            
+            Action action = () =>
             {
-                cut.MarkupMatches("<fluent-button " +
-                                  "type=\"button\" " +
-                                  "appearance=\"neutral\" " +
-                                  $"formtarget=\"{formTarget}\"> " +
-                                  $"{childContent}" +
-                                  "</fluent-button>");
-            }
-            else
-            {
-                cut.MarkupMatches("<fluent-button " +
-                                  "type=\"button\" " +
-                                  "appearance=\"neutral\">" +
-                                  $"{childContent}" +
-                                  "</fluent-button>");
-            }
+                TestContext.RenderComponent<FluentButton>(
+                    parameters => parameters
+                        .Add(p => p.Target, formTarget)
+                        .AddChildContent(childContent));
+            };
+
+            // Assert
+            action.Should().Throw<ArgumentException>();
+            // cut.MarkupMatches("<fluent-button " +
+            //                   "type=\"button\" " +
+            //                   "appearance=\"neutral\" " +
+            //                   $"formtarget=\"{formTarget}\"> " +
+            //                   $"{childContent}" +
+            //                   "</fluent-button>");
         }
 
         [Theory]

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Calendar/CalendarRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Calendar/CalendarRenderShould.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using FluentAssertions;
 using Xunit;
 
 namespace Microsoft.Fast.Components.FluentUI.Tests.Calendar
@@ -30,30 +31,46 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Calendar
         }
 
         [Theory]
-        [InlineData(10)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(7)]
+        [InlineData(12)]
         [InlineData(13)]
         public void RenderProperly_MonthAttribute(int month)
         {
             // Arrange && Act
             string childContent = "fluent-calendar";
-            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
-                parameters => parameters
-                    .Add(p => p.Month, month)
-                    .AddChildContent(childContent));
+            IRenderedComponent<FluentCalendar> cut = null;
+            Action action = () =>
+            {
+                cut = TestContext.RenderComponent<FluentCalendar>(
+                    parameters => parameters
+                        .Add(p => p.Month, month)
+                        .AddChildContent(childContent));
+            };
 
             // Assert
-            cut.MarkupMatches("<fluent-calendar " +
-                              "readonly=\"false\" " +
-                              $"month=\"{month}\" " +
-                              $"year=\"{DateTime.Now.Year}\" " +
-                              "day-format=\"numeric\" " +
-                              "weekday-format=\"short\" " +
-                              "month-format=\"long\" " +
-                              "year-format=\"numeric\" " +
-                              "min-weeks=\"4\" " +
-                              "selected-dates=\"\">" +
-                              $"{childContent}" +
-                              "</fluent-calendar>");
+            if (month > 12 || month < 1)
+            {
+                action.Should().Throw<ArgumentException>();
+            }
+            else
+            {
+                action.Should().NotThrow();
+                cut.MarkupMatches("<fluent-calendar " +
+                                  "readonly=\"false\" " +
+                                  $"month=\"{month}\" " +
+                                  $"year=\"{DateTime.Now.Year}\" " +
+                                  "day-format=\"numeric\" " +
+                                  "weekday-format=\"short\" " +
+                                  "month-format=\"long\" " +
+                                  "year-format=\"numeric\" " +
+                                  "min-weeks=\"4\" " +
+                                  "selected-dates=\"\">" +
+                                  $"{childContent}" +
+                                  "</fluent-calendar>");
+            }
         }
 
         [Fact]

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Calendar/CalendarRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Calendar/CalendarRenderShould.cs
@@ -1,0 +1,517 @@
+using Bunit;
+using Xunit;
+
+namespace Microsoft.Fast.Components.FluentUI.Tests.Calendar
+{
+    public class CalendarRenderShould : TestBase
+    {
+        [Fact]
+        public void RenderProperly_Default()
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              "readonly=\"false\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              "day-format=\"numeric\" " +
+                              "weekday-format=\"short\" " +
+                              "month-format=\"long\" " +
+                              "year-format=\"numeric\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        [Theory]
+        [InlineData(10)]
+        [InlineData(13)]
+        public void RenderProperly_MonthAttribute(int month)
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.Month, month)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              "readonly=\"false\" " +
+                              $"month=\"{month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              "day-format=\"numeric\" " +
+                              "weekday-format=\"short\" " +
+                              "month-format=\"long\" " +
+                              "year-format=\"numeric\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        [Fact]
+        public void RenderProperly_YearAttribute()
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            int year = 2022;
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.Year, year)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              "readonly=\"false\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{year}\" " +
+                              "day-format=\"numeric\" " +
+                              "weekday-format=\"short\" " +
+                              "month-format=\"long\" " +
+                              "year-format=\"numeric\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        [Theory]
+        [InlineData("en-GB")]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void RenderProperly_LocaleAttribute(string? locale)
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.Locale, locale)
+                    .AddChildContent(childContent));
+
+            // Assert
+            if (locale is not null)
+            {
+                cut.MarkupMatches("<fluent-calendar " +
+                                  "readonly=\"false\" " +
+                                  $"locale=\"{locale}\" " +
+                                  $"month=\"{DateTime.Now.Month}\" " +
+                                  $"year=\"{DateTime.Now.Year}\" " +
+                                  "day-format=\"numeric\" " +
+                                  "weekday-format=\"short\" " +
+                                  "month-format=\"long\" " +
+                                  "year-format=\"numeric\" " +
+                                  "min-weeks=\"4\" " +
+                                  "selected-dates=\"\">" +
+                                  $"{childContent}" +
+                                  "</fluent-calendar>");
+            }
+            else
+            {
+                cut.MarkupMatches("<fluent-calendar " +
+                                  "readonly=\"false\" " +
+                                  $"month=\"{DateTime.Now.Month}\" " +
+                                  $"year=\"{DateTime.Now.Year}\" " +
+                                  "day-format=\"numeric\" " +
+                                  "weekday-format=\"short\" " +
+                                  "month-format=\"long\" " +
+                                  "year-format=\"numeric\" " +
+                                  "min-weeks=\"4\" " +
+                                  "selected-dates=\"\">" +
+                                  $"{childContent}" +
+                                  "</fluent-calendar>");
+            }
+        }
+
+        [Theory]
+        [InlineData(DayFormat.Numeric)]
+        [InlineData(DayFormat.TwoDigit)]
+        public void RenderProperly_DayFormatAttribute(DayFormat dayFormat)
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.DayFormat, dayFormat)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              "readonly=\"false\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              $"day-format=\"{dayFormat.ToAttributeValue()}\" " +
+                              "weekday-format=\"short\" " +
+                              "month-format=\"long\" " +
+                              "year-format=\"numeric\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        [Theory]
+        [InlineData(WeekdayFormat.Long)]
+        [InlineData(WeekdayFormat.Narrow)]
+        [InlineData(WeekdayFormat.Short)]
+        public void RenderProperly_WeekDayFormatAttribute(WeekdayFormat weekdayFormat)
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.WeekdayFormat, weekdayFormat)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              "readonly=\"false\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              "day-format=\"numeric\" " +
+                              $"weekday-format=\"{weekdayFormat.ToAttributeValue()}\" " +
+                              "month-format=\"long\" " +
+                              "year-format=\"numeric\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        [Theory]
+        [InlineData(MonthFormat.Long)]
+        [InlineData(MonthFormat.Narrow)]
+        [InlineData(MonthFormat.Numeric)]
+        [InlineData(MonthFormat.Short)]
+        [InlineData(MonthFormat.TwoDigit)]
+        public void RenderProperly_MonthFormatAttribute(MonthFormat monthFormat)
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.MonthFormat, monthFormat)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              "readonly=\"false\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              "day-format=\"numeric\" " +
+                              "weekday-format=\"short\" " +
+                              $"month-format=\"{monthFormat.ToAttributeValue()}\" " +
+                              "year-format=\"numeric\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        [Theory]
+        [InlineData(YearFormat.Numeric)]
+        [InlineData(YearFormat.TwoDigit)]
+        public void RenderProperly_YearFormatAttribute(YearFormat yearFormat)
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.YearFormat, yearFormat)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              "readonly=\"false\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              "day-format=\"numeric\" " +
+                              "weekday-format=\"short\" " +
+                              "month-format=\"long\" " +
+                              $"year-format=\"{yearFormat.ToAttributeValue()}\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        [Fact]
+        public void RenderProperly_MinWeeksAttribute()
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            int minWeeks = 6;
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.MinWeeks, minWeeks)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              "readonly=\"false\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              "day-format=\"numeric\" " +
+                              "weekday-format=\"short\" " +
+                              "month-format=\"long\" " +
+                              "year-format=\"numeric\" " +
+                              $"min-weeks=\"{minWeeks}\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        public static IEnumerable<object[]> RenderProperly_DisabledDatesAttribute_TestData = new List<object[]>
+        {
+            new object[] { new List<DateOnly>() },
+            new object[] { new List<DateOnly> { new DateOnly(2022, 12, 13) } },
+            new object[] { new List<DateOnly> { new DateOnly(2022, 12, 13), new DateOnly(2022, 12, 23) } }
+        };
+
+        [Theory]
+        [MemberData(nameof(RenderProperly_DisabledDatesAttribute_TestData))]
+        public void RenderProperly_DisabledDatesAttribute(IEnumerable<DateOnly>? disabledDates)
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.DisabledDates, disabledDates)
+                    .AddChildContent(childContent));
+
+            // Assert
+            if (disabledDates is not null)
+            {
+                string disabled = string.Join(",",
+                    disabledDates.OrderBy(d => d.DayNumber).Select(s => s.ToString("M-d-yyyy")));
+                cut.MarkupMatches("<fluent-calendar " +
+                                  "readonly=\"false\" " +
+                                  $"month=\"{DateTime.Now.Month}\" " +
+                                  $"year=\"{DateTime.Now.Year}\" " +
+                                  "day-format=\"numeric\" " +
+                                  "weekday-format=\"short\" " +
+                                  "month-format=\"long\" " +
+                                  "year-format=\"numeric\" " +
+                                  "min-weeks=\"4\" " +
+                                  "selected-dates=\"\" " +
+                                  $"disabled-dates=\"{disabled}\">" +
+                                  $"{childContent}" +
+                                  "</fluent-calendar>");
+            }
+            else
+            {
+                cut.MarkupMatches("<fluent-calendar " +
+                                  "readonly=\"false\" " +
+                                  $"month=\"{DateTime.Now.Month}\" " +
+                                  $"year=\"{DateTime.Now.Year}\" " +
+                                  "day-format=\"numeric\" " +
+                                  "weekday-format=\"short\" " +
+                                  "month-format=\"long\" " +
+                                  "year-format=\"numeric\" " +
+                                  "min-weeks=\"4\" " +
+                                  "selected-dates=\"\">" +
+                                  $"{childContent}" +
+                                  "</fluent-calendar>");
+            }
+        }
+
+        public static IEnumerable<object[]> RenderProperly_SelectedDatesAttribute_TestData = new List<object[]>
+        {
+            new object[] { new List<DateOnly>() },
+            new object[] { new List<DateOnly> { new DateOnly(2022, 12, 13) } },
+            new object[] { new List<DateOnly> { new DateOnly(2022, 12, 13), new DateOnly(2022, 12, 23) } }
+        };
+
+        [Theory]
+        [MemberData(nameof(RenderProperly_SelectedDatesAttribute_TestData))]
+        public void RenderProperly_SelectedDatesAttribute(IEnumerable<DateOnly>? selectedDates)
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.SelectedDates, selectedDates)
+                    .AddChildContent(childContent));
+
+            // Assert
+            if (selectedDates is not null)
+            {
+                string selected = string.Join(",",
+                    selectedDates.OrderBy(d => d.DayNumber).Select(s => s.ToString("M-d-yyyy")));
+                cut.MarkupMatches("<fluent-calendar " +
+                                  "readonly=\"false\" " +
+                                  $"month=\"{DateTime.Now.Month}\" " +
+                                  $"year=\"{DateTime.Now.Year}\" " +
+                                  "day-format=\"numeric\" " +
+                                  "weekday-format=\"short\" " +
+                                  "month-format=\"long\" " +
+                                  "year-format=\"numeric\" " +
+                                  "min-weeks=\"4\" " +
+                                  $"selected-dates=\"{selected}\">" +
+                                  $"{childContent}" +
+                                  "</fluent-calendar>");
+            }
+            else
+            {
+                cut.MarkupMatches("<fluent-calendar " +
+                                  "readonly=\"false\" " +
+                                  $"month=\"{DateTime.Now.Month}\" " +
+                                  $"year=\"{DateTime.Now.Year}\" " +
+                                  "day-format=\"numeric\" " +
+                                  "weekday-format=\"short\" " +
+                                  "month-format=\"long\" " +
+                                  "year-format=\"numeric\" " +
+                                  "min-weeks=\"4\" " +
+                                  "selected-dates=\"\">" +
+                                  $"{childContent}" +
+                                  "</fluent-calendar>");
+            }
+        }
+
+        [Fact]
+        public void RenderProperly_ReadonlyAttribute()
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.Readonly, true)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              "readonly=\"true\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              "day-format=\"numeric\" " +
+                              "weekday-format=\"short\" " +
+                              "month-format=\"long\" " +
+                              "year-format=\"numeric\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        [Fact]
+        public void RenderProperly_ClassAttribute()
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            string className = "class-name";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.Class, className)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              $"class=\"{className}\" " +
+                              "readonly=\"false\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              "day-format=\"numeric\" " +
+                              "weekday-format=\"short\" " +
+                              "month-format=\"long\" " +
+                              "year-format=\"numeric\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        [Fact]
+        public void RenderProperly_StyleAttribute()
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            string style = "background-color:yellow;";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .Add(p => p.Style, style)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              $"style=\"{style}\" " +
+                              "readonly=\"false\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              "day-format=\"numeric\" " +
+                              "weekday-format=\"short\" " +
+                              "month-format=\"long\" " +
+                              "year-format=\"numeric\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        [Fact]
+        public void RenderProperly_AdditionalAttribute()
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            string additionalAttributeName = "additional-attribute-name";
+            string additionalAttributeValue = "additional-attribute-value";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .AddUnmatched(additionalAttributeName, additionalAttributeValue)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              $"{additionalAttributeName}=\"{additionalAttributeValue}\" " +
+                              "readonly=\"false\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              "day-format=\"numeric\" " +
+                              "weekday-format=\"short\" " +
+                              "month-format=\"long\" " +
+                              "year-format=\"numeric\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+
+        [Fact]
+        public void RenderProperly_AdditionalAttributes()
+        {
+            // Arrange && Act
+            string childContent = "fluent-calendar";
+            string additionalAttribute1Name = "additional-attribute1-name";
+            string additionalAttribute1Value = "additional-attribute1-value";
+            string additionalAttribute2Name = "additional-attribute2-name";
+            string additionalAttribute2Value = "additional-attribute2-value";
+            IRenderedComponent<FluentCalendar> cut = TestContext.RenderComponent<FluentCalendar>(
+                parameters => parameters
+                    .AddUnmatched(additionalAttribute1Name, additionalAttribute1Value)
+                    .AddUnmatched(additionalAttribute2Name, additionalAttribute2Value)
+                    .AddChildContent(childContent));
+
+            // Assert
+            cut.MarkupMatches("<fluent-calendar " +
+                              $"{additionalAttribute1Name}=\"{additionalAttribute1Value}\" " +
+                              $"{additionalAttribute2Name}=\"{additionalAttribute2Value}\" " +
+                              "readonly=\"false\" " +
+                              $"month=\"{DateTime.Now.Month}\" " +
+                              $"year=\"{DateTime.Now.Year}\" " +
+                              "day-format=\"numeric\" " +
+                              "weekday-format=\"short\" " +
+                              "month-format=\"long\" " +
+                              "year-format=\"numeric\" " +
+                              "min-weeks=\"4\" " +
+                              "selected-dates=\"\">" +
+                              $"{childContent}" +
+                              "</fluent-calendar>");
+        }
+    }
+}

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Calendar/FluentCalendar.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Calendar/FluentCalendar.razor.cs
@@ -48,7 +48,7 @@ public partial class FluentCalendar : FluentComponentBase
     public bool Readonly { get; set; } = false;
 
     /// <summary>
-    /// String repesentation of the full locale including market, calendar type and numbering system
+    /// String representation of the full locale including market, calendar type and numbering system
     /// </summary>
     [Parameter]
     public string? Locale { get; set; }


### PR DESCRIPTION
# Pull Request

## 📖 Description

bUnit tests against FluentButton and FluentCalendar components.
The tests check the HTML output of the components

### 🎫 Issues

- no relevant issue

## 👩‍💻 Reviewer Notes

- in case of both components the extras provided by FluentComponentBase are checked
- attributes are covered, in case of string null, empty and whitespace is checked
- in case of enum input all enum value is exercised
- in case of FluentCalendar the Month input is not validated, so I added a tests where `13` is the input to show that there is no validation here. I assume there are people checking the tests to understand how component works.
- [the xml doc of the button form target](https://github.com/microsoft/fast-blazor/blob/3f3b741b7602adb9c7ca67d762f86991eacb46bf/src/Microsoft.Fast.Components.FluentUI/Components/Button/FluentButton.razor.cs#L47) determines valid values, but no validation.
- as for the two validation above, is there a plan to add validation there?

## 📑 Test Plan

- N/A

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->