### PR TITLE
fix: tests against FluentCard and other fixes

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Anchor/FluentAnchorRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Anchor/FluentAnchorRenderShould.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using FluentAssertions;
 using Xunit;
 
 namespace Microsoft.Fast.Components.FluentUI.Tests.Anchor
@@ -164,24 +165,37 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Anchor
         [InlineData("_self")]
         [InlineData("_parent")]
         [InlineData("_top")]
+        [InlineData("invalid")]
         public void RenderProperly_TargetAttribute(string target)
         {
             // Arrange
             TestContext.JSInterop.SetupModule(
                 "./_content/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.js");
-            IRenderedComponent<FluentUI.FluentAnchor> cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
-                parameters => parameters
-                    .Add(p => p.Target, target)
-                    .Add(p => p.Href, "https://fast.design")
-                    .AddChildContent("click me!"));
+            IRenderedComponent<FluentUI.FluentAnchor>? cut = null;
+            Action action = () =>
+            {
+                cut = TestContext.RenderComponent<FluentUI.FluentAnchor>(
+                    parameters => parameters
+                        .Add(p => p.Target, target)
+                        .Add(p => p.Href, "https://fast.design")
+                        .AddChildContent("click me!"));
+            };
 
             // Assert
-            cut.MarkupMatches("<fluent-anchor " +
-                              "href=\"https://fast.design\" " +
-                              "appearance=\"neutral\" " +
-                              $"target=\"{target}\">" +
-                              "click me!" +
-                              "</fluent-anchor>");
+            if (target == "invalid")
+            {
+                action.Should().Throw<ArgumentException>();
+            }
+            else
+            {
+                action.Should().NotThrow();
+                cut!.MarkupMatches("<fluent-anchor " +
+                                   "href=\"https://fast.design\" " +
+                                   "appearance=\"neutral\" " +
+                                   $"target=\"{target}\">" +
+                                   "click me!" +
+                                   "</fluent-anchor>");
+            }
         }
 
         [Theory]

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Badge/FluentBadgeRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Badge/FluentBadgeRenderShould.cs
@@ -26,19 +26,32 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Badge
         [InlineData(Appearance.Neutral)]
         [InlineData(Appearance.Accent)]
         [InlineData(Appearance.Lightweight)]
+        [InlineData(Appearance.Hypertext)]
         public void RenderProperly_AppearanceAttribute(Appearance appearance)
         {
             // Arrange && Act
-            IRenderedComponent<FluentBadge> cut = TestContext.RenderComponent<FluentBadge>(
-                parameters => parameters
-                    .Add(p => p.Appearance, appearance)
-                    .AddChildContent("childcontent"));
+            IRenderedComponent<FluentBadge>? cut = null;
+            Action action = () =>
+            {
+                cut = TestContext.RenderComponent<FluentBadge>(
+                    parameters => parameters
+                        .Add(p => p.Appearance, appearance)
+                        .AddChildContent("childcontent"));
+            };
             
             // Assert
-            cut.MarkupMatches("<fluent-badge " +
-                              $"appearance=\"{appearance.ToAttributeValue()}\">" +
-                              "childcontent" +
-                              "</fluent-badge>");
+            if (appearance == Appearance.Hypertext)
+            {
+                action.Should().Throw<ArgumentException>();
+            }
+            else
+            {
+                action.Should().NotThrow();
+                cut!.MarkupMatches("<fluent-badge " +
+                                  $"appearance=\"{appearance.ToAttributeValue()}\">" +
+                                  "childcontent" +
+                                  "</fluent-badge>");
+            }
         }
         
         [Theory]

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Breadcrumb/BreadcrumbItemRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Breadcrumb/BreadcrumbItemRenderShould.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using FluentAssertions;
 using Xunit;
 
 namespace Microsoft.Fast.Components.FluentUI.Tests.Breadcrumb
@@ -137,20 +138,33 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Breadcrumb
         [InlineData("_self")]
         [InlineData("_parent")]
         [InlineData("_top")]
+        [InlineData("invalid")]
         public void RenderProperly_TargetAttribute(string targetAttribute)
         {
             // Arrange && Act
             string childContent = "childContent";
-            IRenderedComponent<FluentBreadcrumbItem> cut = TestContext.RenderComponent<FluentBreadcrumbItem>(
-                attributes => attributes
-                    .Add(p => p.Target, targetAttribute)
-                    .AddChildContent(childContent));
+            IRenderedComponent<FluentBreadcrumbItem>? cut = null;
+            Action action = () =>
+            {
+                cut = TestContext.RenderComponent<FluentBreadcrumbItem>(
+                    attributes => attributes
+                        .Add(p => p.Target, targetAttribute)
+                        .AddChildContent(childContent));
+            };
             
             // Assert
-            cut.MarkupMatches("<fluent-breadcrumb-item " +
-                              $"target=\"{targetAttribute}\">" +
-                              $"{childContent}" +
-                              "</fluent-breadcrumb-item>");
+            if (targetAttribute == "invalid")
+            {
+                action.Should().Throw<ArgumentException>();
+            }
+            else
+            {
+                action.Should().NotThrow();
+                cut!.MarkupMatches("<fluent-breadcrumb-item " +
+                                  $"target=\"{targetAttribute}\">" +
+                                  $"{childContent}" +
+                                  "</fluent-breadcrumb-item>");
+            }
         }
         
         [Theory]

--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Card/CardRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Card/CardRenderShould.cs
@@ -1,0 +1,96 @@
+using Bunit;
+using Xunit;
+
+namespace Microsoft.Fast.Components.FluentUI.Tests.Card
+{
+    public class CardRenderShould : TestBase
+    {
+        [Fact]
+        public void RenderProperly_Default()
+        {
+            // Arrange && Act
+            string childContent = "childcontent";
+            IRenderedComponent<FluentCard> cut = TestContext.RenderComponent<FluentCard>(parameters => parameters
+                .AddChildContent(childContent));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-card>" +
+                              $"{childContent}" +
+                              "</fluent-card>");
+        }
+        
+        [Fact]
+        public void RenderProperly_AdditionalCssClass()
+        {
+            // Arrange && Act
+            string childContent = "childcontent";
+            string cssClass = "css-class";
+            IRenderedComponent<FluentCard> cut = TestContext.RenderComponent<FluentCard>(parameters => parameters
+                .AddChildContent(childContent)
+                .Add(p =>p.Class, cssClass));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-card " +
+                              $"class=\"{cssClass}\">" +
+                              $"{childContent}" +
+                              "</fluent-card>");
+        }
+        
+        [Fact]
+        public void RenderProperly_AdditionalStyle()
+        {
+            // Arrange && Act
+            string childContent = "childcontent";
+            string style = "background-color: red;";
+            IRenderedComponent<FluentCard> cut = TestContext.RenderComponent<FluentCard>(parameters => parameters
+                .AddChildContent(childContent)
+                .Add(p =>p.Style, style));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-card " +
+                              $"style=\"{style}\">" +
+                              $"{childContent}" +
+                              "</fluent-card>");
+        }
+        
+        [Fact]
+        public void RenderProperly_AdditionalParameter()
+        {
+            // Arrange && Act
+            string childContent = "childcontent";
+            string additionalParameterName = "additional-parameter-name";
+            string additionalParameterValue = "additional-parameter-value";
+            IRenderedComponent<FluentCard> cut = TestContext.RenderComponent<FluentCard>(parameters => parameters
+                .AddChildContent(childContent)
+                .AddUnmatched(additionalParameterName, additionalParameterValue));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-card " +
+                              $"{additionalParameterName}=\"{additionalParameterValue}\">" +
+                              $"{childContent}" +
+                              "</fluent-card>");
+        }
+        
+        [Fact]
+        public void RenderProperly_AdditionalParameters()
+        {
+            // Arrange && Act
+            string childContent = "childcontent";
+            string additionalParameter1Name = "additional-parameter1-name";
+            string additionalParameter1Value = "additional-parameter1-value";            
+            string additionalParameter2Name = "additional-parameter2-name";
+            string additionalParameter2Value = "additional-parameter2-value";
+            IRenderedComponent<FluentCard> cut = TestContext.RenderComponent<FluentCard>(parameters => parameters
+                .AddChildContent(childContent)
+                .AddUnmatched(additionalParameter1Name, additionalParameter1Value)
+                .AddUnmatched(additionalParameter2Name, additionalParameter2Value));
+            
+            // Assert
+            cut.MarkupMatches("<fluent-card " +
+                              $"{additionalParameter1Name}=\"{additionalParameter1Value}\" " +
+                              $"{additionalParameter2Name}=\"{additionalParameter2Value}\">" +
+                              $"{childContent}" +
+                              "</fluent-card>");
+        }
+    }
+}

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Anchor/FluentAnchor.razor.cs
@@ -80,6 +80,10 @@ public partial class FluentAnchor : FluentComponentBase, IAsyncDisposable
 
     protected override void OnParametersSet()
     {
+        string[] values = { "_self", "_blank", "_parent", "_top" };
+        if (!string.IsNullOrEmpty(Target) && !values.Contains(Target))
+            throw new ArgumentException("Target must be one of the following values: _self, _blank, _parent, _top");
+        
         // If the Href has been specified (as it should) and if starts with '#,'
         // we assume the rest of the value contains the id of the element the link points to.
         if (!string.IsNullOrEmpty(Href) && Href.StartsWith('#'))

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Breadcrumb/FluentBreadcrumbItem.razor.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Breadcrumb/FluentBreadcrumbItem.razor.cs
@@ -65,4 +65,13 @@ public partial class FluentBreadcrumbItem : FluentComponentBase
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        string[] values = { "_self", "_blank", "_parent", "_top" };
+        if (!string.IsNullOrEmpty(Target) && !values.Contains(Target))
+            throw new ArgumentException("Target must be one of the following values: _self, _blank, _parent, _top");
+        
+        base.OnParametersSet();
+    }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

This Pr contains the following changes:
- bunit render tests against FluentCard, the tests checking the rendered HTML
- Target parameter input validation for FluentAnchor and tests extended accordingly
- FluentBadge appearance input parameter validation tests
- Target parameter input validation for FluentBreadcrumbItem and tests extended accordingly

### 🎫 Issues

- there are no related issues

## 👩‍💻 Reviewer Notes

- I apologise in advance because I feel that this PR might be bigger/wider than it should be, I wanted to make these changes in one go
- in case of FluentAnchor and FluentBreadcrimbItem Target parameter validation I followed the pattern I found at other components, however I see the opportunity to extract Target possible values and use this common list across components
- the build of this PR will display warnings until #309 is not merged, once it is merged warnings should disappear

## 📑 Test Plan

- the component changes come with their tests

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->