### PR TITLE
fix: FluentCheckbox class tag always displayed

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI.Tests/Checkbox/CheckboxRenderShould.cs
+++ b/src/Microsoft.Fast.Components.FluentUI.Tests/Checkbox/CheckboxRenderShould.cs
@@ -5,38 +5,69 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Checkbox
 {
     public class CheckboxRenderShould : TestBase
     {
-        [Fact]
-        public void RenderProperly_DefaultValues()
-        {
-            // Arrange && Act
-            string childContent = "childContent";
-            IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
-                parameters => parameters
-                    .AddChildContent(childContent));
-            
-            // Assert
-            sut.MarkupMatches("<fluent-checkbox>" +
-                              $"{childContent}" +
-                              "</fluent-checkbox>");
-        }
-        
-        [Fact]
-        public void RenderProperly_ReadonlyParameter()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RenderProperly_DefaultValues(bool currentValue)
         {
             // Arrange && Act
             string childContent = "childContent";
             IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
                 parameters => parameters
                     .AddChildContent(childContent)
-                    .Add(p => p.Readonly, true));
-            
+                    .Bind(bind => bind.Value, currentValue, newValue => currentValue = false));
+
             // Assert
-            sut.MarkupMatches("<fluent-checkbox " +
-                              "readonly=\"\">" +
-                              $"{childContent}" +
-                              "</fluent-checkbox>");
+            if (currentValue)
+            {
+                sut.MarkupMatches("<fluent-checkbox " +
+                                  "value=\"\" " +
+                                  "current-value=\"\" " +
+                                  "current-checked=\"\">" +
+                                  $"{childContent}" +
+                                  "</fluent-checkbox>");
+            }
+            else
+            {
+                sut.MarkupMatches("<fluent-checkbox>" +
+                                  $"{childContent}" +
+                                  "</fluent-checkbox>");
+            }
         }
-        
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RenderProperly_ReadonlyParameter(bool currentValue)
+        {
+            // Arrange && Act
+            string childContent = "childContent";
+            IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
+                parameters => parameters
+                    .AddChildContent(childContent)
+                    .Bind(p => p.Value, currentValue, newValue => currentValue = false)
+                    .Add(p => p.Readonly, true));
+
+            // Assert
+            if (currentValue)
+            {
+                sut.MarkupMatches("<fluent-checkbox  " +
+                                  "value=\"\" " +
+                                  "current-value=\"\" " +
+                                  "current-checked=\"\" " +
+                                  "readonly=\"\">" +
+                                  $"{childContent}" +
+                                  "</fluent-checkbox>");
+            }
+            else
+            {
+                sut.MarkupMatches("<fluent-checkbox " +
+                                  "readonly=\"\">" +
+                                  $"{childContent}" +
+                                  "</fluent-checkbox>");
+            }
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -46,44 +77,57 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Checkbox
         {
             // Arrange && Act
             string childContent = "childContent";
+            bool currentValue = true;
             IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
                 parameters => parameters
                     .AddChildContent(childContent)
+                    .Bind(p => p.Value, currentValue, newValue => currentValue = true)
                     .Add(p => p.Id, idParameter));
-            
+
             // Assert
             if (idParameter is null)
             {
-                sut.MarkupMatches("<fluent-checkbox>" +
+                sut.MarkupMatches("<fluent-checkbox " +
+                                  "value=\"\" " +
+                                  "current-value=\"\" " +
+                                  "current-checked=\"\">" +
                                   $"{childContent}" +
                                   "</fluent-checkbox>");
             }
             else
             {
                 sut.MarkupMatches("<fluent-checkbox " +
-                                  $"id=\"{idParameter}\">" +
+                                  $"id=\"{idParameter}\" " +
+                                  "value=\"\" " +
+                                  "current-value=\"\" " +
+                                  "current-checked=\"\">" +
                                   $"{childContent}" +
                                   "</fluent-checkbox>");
             }
         }
-        
+
         [Fact]
         public void RenderProperly_DisabledParameter()
         {
             // Arrange && Act
             string childContent = "childContent";
+            bool currentValue = true;
             IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
                 parameters => parameters
                     .AddChildContent(childContent)
+                    .Bind(p => p.Value, currentValue, newValue => currentValue = false)
                     .Add(p => p.Disabled, true));
-            
+
             // Assert
             sut.MarkupMatches("<fluent-checkbox " +
+                              "value=\"\" " +
+                              "current-value=\"\" " +
+                              "current-checked=\"\" " +
                               "disabled=\"\">" +
                               $"{childContent}" +
                               "</fluent-checkbox>");
         }
-        
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -93,108 +137,103 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Checkbox
         {
             // Arrange && Act
             string childContent = "childContent";
+            bool currentValue = true;
             IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
                 parameters => parameters
                     .AddChildContent(childContent)
+                    .Bind(p => p.Value, currentValue, newValue => currentValue = false)
                     .Add(p => p.Name, nameParameter));
-            
+
             // Assert
             if (nameParameter is null)
             {
-                sut.MarkupMatches("<fluent-checkbox>" +
+                sut.MarkupMatches("<fluent-checkbox  " +
+                                  "value=\"\" " +
+                                  "current-value=\"\" " +
+                                  "current-checked=\"\">" +
                                   $"{childContent}" +
                                   "</fluent-checkbox>");
             }
             else
             {
-                sut.MarkupMatches("<fluent-checkbox " +
+                sut.MarkupMatches("<fluent-checkbox  " +
+                                  "value=\"\" " +
+                                  "current-value=\"\" " +
+                                  "current-checked=\"\" " +
                                   $"name=\"{nameParameter}\">" +
                                   $"{childContent}" +
                                   "</fluent-checkbox>");
             }
         }
-        
+
         [Fact]
         public void RenderProperly_RequiredParameter()
         {
             // Arrange && Act
             string childContent = "childContent";
+            bool currentValue = true;
             IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
                 parameters => parameters
                     .AddChildContent(childContent)
+                    .Bind(p => p.Value, currentValue, newValue => currentValue = false)
                     .Add(p => p.Required, true));
-            
+
             // Assert
             sut.MarkupMatches("<fluent-checkbox " +
-                              "required=\"\">" +
+                              "required=\"\"  " +
+                              "value=\"\" " +
+                              "current-value=\"\" " +
+                              "current-checked=\"\">" +
                               $"{childContent}" +
                               "</fluent-checkbox>");
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void RenderProperly_ValueParameter(bool value)
-        {
-            // Arrange && Act
-            string childContent = "childContent";
-            IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
-                parameters => parameters
-                    .AddChildContent(childContent)
-                    .Add(p => p.Value, value));
-            
-            // Assert
-            if (value)
-            {
-                sut.MarkupMatches("<fluent-checkbox " +
-                                  "value=\"\" current-value=\"\" current-checked=\"\">" +
-                                  $"{childContent}" +
-                                  "</fluent-checkbox>");
-            }
-            else
-            {
-                sut.MarkupMatches("<fluent-checkbox>" +
-                                  $"{childContent}" +
-                                  "</fluent-checkbox>");
-            }
-        }
-        
         [Fact]
         public void RenderProperly_ClassParameter()
         {
             // Arrange && Act
             string childContent = "childContent";
             string cssClass = "additional-css-class";
+            bool currentValue = true;
             IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
                 parameters => parameters
                     .AddChildContent(childContent)
+                    .Bind(p => p.Value, currentValue, newValue => currentValue = false)
                     .Add(p => p.Class, cssClass));
-            
+
             // Assert
             sut.MarkupMatches("<fluent-checkbox " +
-                              $"class=\"{cssClass}\">" +
+                              $"class=\"{cssClass}\"  " +
+                              "value=\"\" " +
+                              "current-value=\"\" " +
+                              "current-checked=\"\">" +
                               $"{childContent}" +
                               "</fluent-checkbox>");
         }
-        
+
         [Fact]
         public void RenderProperly_StyleParameter()
         {
             // Arrange && Act
             string childContent = "childContent";
             string style = "background-color: red;";
+            bool currentValue = true;
             IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
                 parameters => parameters
                     .AddChildContent(childContent)
+                    .Bind(p => p.Value, currentValue, newValue => currentValue = false)
                     .Add(p => p.Style, style));
-            
+
             // Assert
             sut.MarkupMatches("<fluent-checkbox " +
-                              $"style=\"{style}\">" +
+                              $"style=\"{style}\"  " +
+                              "value=\"\" " +
+                              "current-value=\"\" " +
+                              "current-checked=\"\">" +
                               $"{childContent}" +
                               "</fluent-checkbox>");
         }
-        
+
         [Fact]
         public void RenderProperly_AdditionalParameter()
         {
@@ -202,18 +241,23 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Checkbox
             string childContent = "childContent";
             string parameterName = "parameterName";
             string parameterValue = "parameterValue";
+            bool currentValue = true;
             IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
                 parameters => parameters
                     .AddChildContent(childContent)
+                    .Bind(p => p.Value, currentValue, newValue => currentValue = false)
                     .AddUnmatched(parameterName, parameterValue));
-            
+
             // Assert
             sut.MarkupMatches("<fluent-checkbox " +
-                              $"{parameterName}=\"{parameterValue}\">" +
+                              $"{parameterName}=\"{parameterValue}\"  " +
+                              "value=\"\" " +
+                              "current-value=\"\" " +
+                              "current-checked=\"\">" +
                               $"{childContent}" +
                               "</fluent-checkbox>");
         }
-        
+
         [Fact]
         public void RenderProperly_AdditionalParameters()
         {
@@ -223,16 +267,21 @@ namespace Microsoft.Fast.Components.FluentUI.Tests.Checkbox
             string parameter1Value = "parameter1Value";
             string parameter2Name = "parameter2Name";
             string parameter2Value = "parameter2Value";
+            bool currentValue = true;
             IRenderedComponent<FluentCheckbox> sut = TestContext.RenderComponent<FluentCheckbox>(
                 parameters => parameters
                     .AddChildContent(childContent)
+                    .Bind(p => p.Value, currentValue, newValue => currentValue = false)
                     .AddUnmatched(parameter1Name, parameter1Value)
                     .AddUnmatched(parameter2Name, parameter2Value));
-            
+
             // Assert
             sut.MarkupMatches("<fluent-checkbox " +
                               $"{parameter1Name}=\"{parameter1Value}\" " +
-                              $"{parameter2Name}=\"{parameter2Value}\">" +
+                              $"{parameter2Name}=\"{parameter2Value}\" " +
+                              "value=\"\" " +
+                              "current-value=\"\" " +
+                              "current-checked=\"\">" +
                               $"{childContent}" +
                               "</fluent-checkbox>");
         }

--- a/src/Microsoft.Fast.Components.FluentUI/Components/Base/FluentInputBase.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Base/FluentInputBase.cs
@@ -83,9 +83,7 @@ public abstract class FluentInputBase<TValue> : FluentComponentBase, IDisposable
     /// </summary>
     [Parameter]
     public string? DisplayName { get; set; }
-
-
-
+    
     /// <summary>
     /// Gets the associated <see cref="AspNetCore.Components.Forms.EditContext"/>.
     /// This property is uninitialized if the input does not have a parent <see cref="EditForm"/>.
@@ -213,11 +211,16 @@ public abstract class FluentInputBase<TValue> : FluentComponentBase, IDisposable
         get
         {
             string? fieldClass = EditContext?.FieldCssClass(FieldIdentifier);
-            string? cssClass = CombineClassNames(AdditionalAttributes, fieldClass) ?? string.Empty;
+            string? cssClass = CombineClassNames(AdditionalAttributes, fieldClass);
 
-            return new CssBuilder(Class)
-                .AddClass(cssClass)
-                .Build();
+            if (!string.IsNullOrEmpty(cssClass) || !string.IsNullOrEmpty(Class))
+            {
+                return new CssBuilder(Class)
+                    .AddClass(cssClass)
+                    .Build();
+            }
+
+            return null;
         }
     }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

[v2.1.0](https://github.com/microsoft/fast-blazor/releases/tag/V2.1.0) brought the `bind-Value` to the components using [FluentInputBase](https://github.com/microsoft/fast-blazor/blob/main/src/Microsoft.Fast.Components.FluentUI/Components/Base/FluentInputBase.cs). As a result `class` attribute is always added to the generated HTML tag (see example below), which unnecessarily increases the HTML size. This PR brings a fix for that and as a result the `class` attribute in the HTML tag is displayed only when it has value.

The wrong result
```razor
<fluent-checkbox class="" value="" current-value="" current-checked="">
childContent
</fluent-checkbox>
```

The proper result
```razor
<fluent-checkbox value="" current-value="" current-checked="">
childContent
</fluent-checkbox>
```

### 🎫 Issues

- no relevant issues

## 👩‍💻 Reviewer Notes

- Not all the components using FluentInputBase covered by tests yet, so there is still some risk the change in this PR includes a bug. If you think a good idea I'm happy to include the tests into this PR. It might take a week or so.

## 📑 Test Plan

- the change in the component comes with its testing, but see my previous comments

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

- tests for all components using FluentInputBase