### PR TITLE
Fix switch click on label and on/off state

### DIFF
--- a/src/Microsoft.Fast.Components.FluentUI/Components/Switch/FluentSwitch.razor
+++ b/src/Microsoft.Fast.Components.FluentUI/Components/Switch/FluentSwitch.razor
@@ -11,7 +11,7 @@
                name=@Name
                required=@Required
                current-checked="@CurrentValue"
-               @oncheckedchange="@((e) => CurrentValue = e.Checked)"
+               @onswitchcheckedchange="@((e) => CurrentValue = e.Checked)"
                @attributes="@AdditionalAttributes">
     @ChildContent
     @if (!string.IsNullOrEmpty(CheckedMessage))

--- a/src/Microsoft.Fast.Components.FluentUI/Events/EventHandlers.cs
+++ b/src/Microsoft.Fast.Components.FluentUI/Events/EventHandlers.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Fast.Components.FluentUI;
 
 
 [EventHandler("oncheckedchange", typeof(CheckboxChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
+[EventHandler("onswitchcheckedchange", typeof(CheckboxChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("oncustomclick", typeof(ChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("ontabchange", typeof(TabChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
 [EventHandler("onselectedchange", typeof(TreeChangeEventArgs), enableStopPropagation: true, enablePreventDefault: true)]

--- a/src/Microsoft.Fast.Components.FluentUI/wwwroot/Microsoft.Fast.Components.FluentUI.lib.module.js
+++ b/src/Microsoft.Fast.Components.FluentUI/wwwroot/Microsoft.Fast.Components.FluentUI.lib.module.js
@@ -15,6 +15,14 @@
             };
         }
     });
+    Blazor.registerCustomEventType('switchcheckedchange', {
+        browserEventName: 'change',
+        createEventArgs: event => {
+            return {
+                checked: event.target.checked
+            };
+        }
+    });
     Blazor.registerCustomEventType('accordionchange', {
         browserEventName: 'change',
         createEventArgs: event => {


### PR DESCRIPTION
# Pull Request

## 📖 Description

When clicking on label or on/off state the control change visually but the `Checked` property isn't updated.
It works correctly only if you click on the switch.

### OLD behaviour:

https://user-images.githubusercontent.com/8057670/226545368-d8ef6461-e483-4380-bcc4-5c6a0f785c44.mp4

### FIXED behaviour:

https://user-images.githubusercontent.com/8057670/226545410-141112f5-8f88-4fcc-aba0-e0f58ce8799e.mp4

### 🎫 Issues

x

## 👩‍💻 Reviewer Notes

x

## 📑 Test Plan

x

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

x