### PR TITLE
[DataGrid] Add SingleSticky selection mode

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -1631,7 +1631,7 @@
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.SelectMode">
             <summary>
-            Gets or sets the selection mode (Single or Multiple).
+            Gets or sets the selection mode (Single, SingleSticky or Multiple).
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.SelectColumn`1.IconUnchecked">
@@ -13667,6 +13667,11 @@
         <member name="F:Microsoft.FluentUI.AspNetCore.Components.DataGridSelectMode.Single">
             <summary>
             Allow only one selected row.
+            </summary>
+        </member>
+        <member name="F:Microsoft.FluentUI.AspNetCore.Components.DataGridSelectMode.SingleSticky">
+            <summary>
+            Allow only one selected row. Keep selection if same row is clicked.
             </summary>
         </member>
         <member name="F:Microsoft.FluentUI.AspNetCore.Components.DataGridSelectMode.Multiple">

--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -82,7 +82,7 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
     public EventCallback<IEnumerable<TGridItem>> SelectedItemsChanged { get; set; }
 
     /// <summary>
-    /// Gets or sets the selection mode (Single or Multiple).
+    /// Gets or sets the selection mode (Single, SingleSticky or Multiple).
     /// </summary>
     [Parameter]
     public DataGridSelectMode SelectMode
@@ -92,7 +92,7 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
         {
             _selectMode = value;
 
-            if (value == DataGridSelectMode.Single)
+            if (value is DataGridSelectMode.Single or DataGridSelectMode.SingleSticky)
             {
                 KeepOnlyFirstSelectedItemAsync().Wait();
             }
@@ -280,6 +280,11 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
     {
         if (item != null && (Selectable == null || Selectable.Invoke(item)))
         {
+            if (SelectMode is DataGridSelectMode.SingleSticky && _selectedItems.Contains(item))
+            {
+                return;
+            }
+
             if (SelectedItems.Contains(item))
             {
                 _selectedItems.Remove(item);
@@ -288,7 +293,7 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
             }
             else
             {
-                if (SelectMode == DataGridSelectMode.Single)
+                if (SelectMode is DataGridSelectMode.Single or DataGridSelectMode.SingleSticky)
                 {
                     foreach (var previous in _selectedItems)
                     {
@@ -324,6 +329,7 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
             return IconChecked ?? SelectMode switch
             {
                 DataGridSelectMode.Single => IconSelectedSingle,
+                DataGridSelectMode.SingleSticky => IconSelectedSingle,
                 _ => IconSelectedMultiple
             };
         }
@@ -332,6 +338,7 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
             return IconUnchecked ?? SelectMode switch
             {
                 DataGridSelectMode.Single => IconUnselectedSingle,
+                DataGridSelectMode.SingleSticky => IconUnselectedSingle,
                 _ => IconUnselectedMultiple
             };
         }
@@ -408,6 +415,9 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>
         switch (SelectMode)
         {
             case DataGridSelectMode.Single:
+                return new RenderFragment((builder) => { });
+
+            case DataGridSelectMode.SingleSticky:
                 return new RenderFragment((builder) => { });
 
             case DataGridSelectMode.Multiple:

--- a/src/Core/Enums/DataGridSelectMode.cs
+++ b/src/Core/Enums/DataGridSelectMode.cs
@@ -12,6 +12,11 @@ public enum DataGridSelectMode
     Single,
 
     /// <summary>
+    /// Allow only one selected row. Keep selection if same row is clicked.
+    /// </summary>
+    SingleSticky,
+
+    /// <summary>
     /// Allow multiple selected rows.
     /// </summary>
     Multiple,

--- a/tests/Core/DataGrid/FluentDataGridColumSelectTests.FluentDataGrid_ColumSelect_SingleStickySelect_Rendering.verified.razor.html
+++ b/tests/Core/DataGrid/FluentDataGridColumSelectTests.FluentDataGrid_ColumSelect_SingleStickySelect_Rendering.verified.razor.html
@@ -1,0 +1,42 @@
+
+<table id="xxx" class="fluent-data-grid grid" style="grid-template-columns: 50px auto;" aria-rowcount="4" blazor:onclosecolumnoptions="1" blazor:onclosecolumnresize="2" b-ppmhrkw1mj="" blazor:elementreference="">
+    <thead b-ppmhrkw1mj="">
+        <tr class="fluent-data-grid-row" data-row-index="0" role="row" row-type="header" blazor:onkeydown="3" blazor:onclick="4" blazor:ondblclick="5" blazor:onfocus="6" b-upi3f9mbnn="">
+            <th col-index="1" class="column-header select-all col-justify-center col-sort-desc" style="grid-column: 1; text-align: center; align-content: center; padding-top: calc(var(--design-unit) * 2.5px); height: 32px; min-height: 44px; display: flex;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="23" blazor:onclick="24" blazor:onfocus="25" scope="col" aria-sort="none" b-w6qdxfylwy=""></th>
+            <th col-index="2" class="column-header col-justify-start col-sort-desc" style="grid-column: 2; height: 32px; min-height: 44px; display: flex;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="26" blazor:onclick="27" blazor:onfocus="28" scope="col" aria-sort="none" b-w6qdxfylwy="">
+                <div class="col-title" style="width: calc(100% - 20px);" b-pxhtqoo8qd="">
+                    <div class="col-title-text" b-pxhtqoo8qd="">Name</div>
+                </div>
+            </th>
+        </tr>
+    </thead>
+    <tbody b-ppmhrkw1mj="">
+        <tr class="fluent-data-grid-row" data-row-index="2" role="row" blazor:onkeydown="11" blazor:onclick="12" blazor:ondblclick="13" blazor:onfocus="14" aria-rowindex="2" b-upi3f9mbnn="">
+            <td col-index="1" class="col-justify-center" style="grid-column: 1; text-align: center; align-content: center; padding-inline-start: calc(((var(--design-unit)* 3) + var(--focus-stroke-width) - var(--stroke-width))* 1px); padding-top: calc(var(--design-unit) * 1.5px); height: 32px;" role="gridcell" tabindex="0" blazor:onkeydown="29" blazor:onclick="30" blazor:onfocus="31" b-w6qdxfylwy="">
+                <svg style="width: 20px; fill: var(--neutral-fill-inverse-rest);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="47" blazor:onclick="48">
+                    <title>Row unselected</title>
+                    <path d="M10 3a7 7 0 1 0 0 14 7 7 0 0 0 0-14Zm-8 7a8 8 0 1 1 16 0 8 8 0 0 1-16 0Z"></path>
+                </svg>
+            </td>
+            <td col-index="2" class="col-justify-start" style="grid-column: 2; height: 32px;" role="gridcell" tabindex="0" blazor:onkeydown="32" blazor:onclick="33" blazor:onfocus="34" b-w6qdxfylwy="">Jean Martin</td>
+        </tr>
+        <tr class="fluent-data-grid-row" data-row-index="3" role="row" blazor:onkeydown="15" blazor:onclick="16" blazor:ondblclick="17" blazor:onfocus="18" aria-rowindex="3" b-upi3f9mbnn="">
+            <td col-index="1" class="col-justify-center" style="grid-column: 1; text-align: center; align-content: center; padding-inline-start: calc(((var(--design-unit)* 3) + var(--focus-stroke-width) - var(--stroke-width))* 1px); padding-top: calc(var(--design-unit) * 1.5px); height: 32px;" role="gridcell" tabindex="0" blazor:onkeydown="35" blazor:onclick="36" blazor:onfocus="37" b-w6qdxfylwy="">
+                <svg style="width: 20px; fill: var(--accent-fill-rest);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="49" blazor:onclick="50" row-selected="">
+                    <title>Row selected.</title>
+                    <path d="M10 15a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0-13a8 8 0 1 0 0 16 8 8 0 0 0 0-16Zm-7 8a7 7 0 1 1 14 0 7 7 0 0 1-14 0Z"></path>
+                </svg>
+            </td>
+            <td col-index="2" class="col-justify-start" style="grid-column: 2; height: 32px;" role="gridcell" tabindex="0" blazor:onkeydown="38" blazor:onclick="39" blazor:onfocus="40" b-w6qdxfylwy="">Kenji Sato</td>
+        </tr>
+        <tr class="fluent-data-grid-row" data-row-index="4" role="row" blazor:onkeydown="19" blazor:onclick="20" blazor:ondblclick="21" blazor:onfocus="22" aria-rowindex="4" b-upi3f9mbnn="">
+            <td col-index="1" class="col-justify-center" style="grid-column: 1; text-align: center; align-content: center; padding-inline-start: calc(((var(--design-unit)* 3) + var(--focus-stroke-width) - var(--stroke-width))* 1px); padding-top: calc(var(--design-unit) * 1.5px); height: 32px;" role="gridcell" tabindex="0" blazor:onkeydown="41" blazor:onclick="42" blazor:onfocus="43" b-w6qdxfylwy="">
+                <svg style="width: 20px; fill: var(--neutral-fill-inverse-rest);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="51" blazor:onclick="52">
+                    <title>Row unselected</title>
+                    <path d="M10 3a7 7 0 1 0 0 14 7 7 0 0 0 0-14Zm-8 7a8 8 0 1 1 16 0 8 8 0 0 1-16 0Z"></path>
+                </svg>
+            </td>
+            <td col-index="2" class="col-justify-start" style="grid-column: 2; height: 32px;" role="gridcell" tabindex="0" blazor:onkeydown="44" blazor:onclick="45" blazor:onfocus="46" b-w6qdxfylwy="">Julie Smith</td>
+        </tr>
+    </tbody>
+</table>

--- a/tests/Core/DataGrid/FluentDataGridColumSelectTests.razor
+++ b/tests/Core/DataGrid/FluentDataGridColumSelectTests.razor
@@ -147,6 +147,180 @@
     }
 
     [Fact]
+    public void FluentDataGrid_ColumSelect_SingleStickySelect_Rendering()
+    {
+        IEnumerable<Person> SelectedItems = new[] { People.ElementAt(1) };
+
+        // Arrange
+        var cut = Render(
+    @<FluentDataGrid Items="@People" TGridItem="Person">
+        <SelectColumn TGridItem="Person"
+                      SelectMode="@DataGridSelectMode.SingleSticky"
+                      @bind-SelectedItems="@SelectedItems" />
+        <PropertyColumn Property="@(p => p.Name)" />
+    </FluentDataGrid>
+    );
+
+        cut.Verify();
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_ColumSelect_SingleStickySelect_SelectedItems()
+    {
+        IEnumerable<Person> SelectedItems = Array.Empty<Person>();
+
+        // Arrange
+        var cut = Render(
+    @<FluentDataGrid Items="@People" TGridItem="Person">
+        <SelectColumn TGridItem="Person"
+                      SelectMode="@DataGridSelectMode.SingleSticky"
+                      @bind-SelectedItems="@SelectedItems" />
+        <PropertyColumn Property="@(p => p.Name)" />
+    </FluentDataGrid>
+        );
+
+        // Pre-Assert
+        Assert.Empty(cut.FindAll("svg[row-selected]"));
+        Assert.Empty(SelectedItems);
+
+        // Act - Click and select Row 0
+        await ClickOnRowAsync(cut, row: 0);
+        Assert.Single(cut.FindAll("svg[row-selected]"));
+        Assert.Single(SelectedItems);
+
+        // Act - Click and select Row 1
+        await ClickOnRowAsync(cut, row: 1);
+        Assert.Single(cut.FindAll("svg[row-selected]"));
+        Assert.Single(SelectedItems);
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_ColumSelect_SingleStickySameItemSelect_SelectedItems()
+    {
+        IEnumerable<Person> SelectedItems = Array.Empty<Person>();
+
+        // Arrange
+        var cut = Render(
+    @<FluentDataGrid Items="@People" TGridItem="Person">
+        <SelectColumn TGridItem="Person"
+                      SelectMode="@DataGridSelectMode.SingleSticky"
+                      @bind-SelectedItems="@SelectedItems" />
+        <PropertyColumn Property="@(p => p.Name)" />
+    </FluentDataGrid>
+        );
+
+        // Pre-Assert
+        Assert.Empty(cut.FindAll("svg[row-selected]"));
+        Assert.Empty(SelectedItems);
+
+        // Act - Click and select Row 0
+        await ClickOnRowAsync(cut, row: 0);
+        Assert.Single(cut.FindAll("svg[row-selected]"));
+        Assert.Single(SelectedItems);
+
+        // Act - Click and select Row 0 a second time
+        await ClickOnRowAsync(cut, row: 0);
+        Assert.Single(cut.FindAll("svg[row-selected]"));
+        Assert.Single(SelectedItems);
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_ColumSelect_Selectable_SingleStickySelect_SelectedItems()
+    {
+        IEnumerable<Person> SelectedItems = Array.Empty<Person>();
+
+        // Arrange
+        var cut = Render(
+    @<FluentDataGrid Items="@People" TGridItem="Person">
+        <SelectColumn TGridItem="Person"
+                      SelectMode="@DataGridSelectMode.SingleSticky"
+                      Selectable="@(e => e.BirthDate.Year >= 2000)"
+                      @bind-SelectedItems="@SelectedItems" />
+        <PropertyColumn Property="@(p => p.Name)" />
+    </FluentDataGrid>
+        );
+
+        // Pre-Assert
+        Assert.Single(cut.FindAll("svg"));
+        Assert.Empty(cut.FindAll("svg[row-selected]"));
+        Assert.Empty(SelectedItems);
+
+        // Act - Click and select Row 0
+        await ClickOnRowAsync(cut, row: 0);
+        Assert.Empty(cut.FindAll("svg[row-selected]"));
+        Assert.Empty(SelectedItems);
+
+        // Act - Click and select Row 1
+        await ClickOnRowAsync(cut, row: 1);
+        Assert.Single(cut.FindAll("svg[row-selected]"));
+        Assert.Single(SelectedItems);
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_ColumSelect_SingleStickySelect_Property()
+    {
+        var items = new List<Person>(People).AsQueryable();
+
+        // Arrange
+        var cut = Render(
+    @<FluentDataGrid Items="@items" TGridItem="Person">
+        <SelectColumn TGridItem="Person"
+                      SelectMode="@DataGridSelectMode.SingleSticky"
+                      Property="@(e => e.Selected)"
+                      OnSelect="@(e => e.Item.Selected = e.Selected)" />
+        <PropertyColumn Property="@(p => p.Name)" />
+    </FluentDataGrid>
+    );
+
+        // Pre-Assert
+        Assert.Empty(cut.FindAll("svg[row-selected]"));
+        Assert.Empty(items.Where(i => i.Selected));
+
+        // Act - Click and select Row 0
+        await ClickOnRowAsync(cut, row: 0);
+        Assert.Single(cut.FindAll("svg[row-selected]"));
+        Assert.Single(items.Where(i => i.Selected));
+
+        // Act - Click and select Row 1
+        await ClickOnRowAsync(cut, row: 1);
+        Assert.Single(cut.FindAll("svg[row-selected]"));
+        Assert.Single(items.Where(i => i.Selected));
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_ColumSelect_Selectable_SingleStickySelect_Property()
+    {
+        var items = new List<Person>(People).AsQueryable();
+
+        // Arrange
+        var cut = Render(
+    @<FluentDataGrid Items="@items" TGridItem="Person">
+        <SelectColumn TGridItem="Person"
+                      SelectMode="@DataGridSelectMode.SingleSticky"
+                      Selectable="@(e => e.BirthDate.Year >= 2000)"
+                      Property="@(e => e.Selected)"
+                      OnSelect="@(e => e.Item.Selected = e.Selected)" />
+        <PropertyColumn Property="@(p => p.Name)" />
+    </FluentDataGrid>
+    );
+
+        // Pre-Assert
+        Assert.Single(cut.FindAll("svg"));
+        Assert.Empty(cut.FindAll("svg[row-selected]"));
+        Assert.Empty(items.Where(i => i.Selected));
+
+        // Act - Click and select Row 0
+        await ClickOnRowAsync(cut, row: 0);
+        Assert.Empty(cut.FindAll("svg[row-selected]"));
+        Assert.Empty(items.Where(i => i.Selected));
+
+        // Act - Click and select Row 1
+        await ClickOnRowAsync(cut, row: 1);
+        Assert.Single(cut.FindAll("svg[row-selected]"));
+        Assert.Single(items.Where(i => i.Selected));
+    }
+
+    [Fact]
     public void FluentDataGrid_ColumSelect_MultiSelect_Rendering()
     {
         IEnumerable<Person> SelectedItems = new[] { People.ElementAt(1), People.ElementAt(2) };


### PR DESCRIPTION
# Pull Request

## 📖 Description

Added `SingleSticky` selection mode to `FluentDataGrid` to retain selection when the same row is clicked again.

### 🎫 Issues
Fix #3138 
## 👩‍💻 Reviewer Notes

## 📑 Test Plan

Duplicated all tests for `Single` selection mode.

## ✅ Checklist

### General

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps


