### PR TITLE
[InputFile] Fix DivideByZeroException in FluentInputFile when uploading 0 byte files (#3717)

### DIFF
--- a/src/Core/Components/InputFile/FluentInputFile.razor.cs
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.cs
@@ -403,7 +403,7 @@ public partial class FluentInputFile : FluentComponentBase, IAsyncDisposable
 
     private Task UpdateProgressAsync(long current, long size, string title)
     {
-        return UpdateProgressAsync(Convert.ToInt32(decimal.Divide(current, size) * 100), title);
+        return UpdateProgressAsync(Convert.ToInt32(decimal.Divide(current, size <= 0 ? 1 : size) * 100), title);
     }
 
     private async Task UpdateProgressAsync(int percent, string title)


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR addresses `DivideByZeroException` when uploading 0 byte files in `FluentInputFile`

### 🎫 Issues

#3717



## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component


