### PR TITLE
[dev-v5] Clarify Button Title behavior in comment and update example

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/Button/Examples/ButtonDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Buttons/Button/Examples/ButtonDefault.razor
@@ -1,5 +1,5 @@
 ﻿<FluentButton OnClick="@ButtonClick">Default</FluentButton>
-<FluentButton OnClick="@ButtonClick" Appearance="ButtonAppearance.Primary">Primary</FluentButton>
+<FluentButton OnClick="@ButtonClick" Appearance="ButtonAppearance.Primary" Title="A tooltip for this button">Primary</FluentButton>
 <FluentButton OnClick="@ButtonClick" Appearance="ButtonAppearance.Outline">Outline</FluentButton>
 <FluentButton OnClick="@ButtonClick" Appearance="ButtonAppearance.Subtle">Subtle</FluentButton>
 <FluentButton OnClick="@ButtonClick" Appearance="ButtonAppearance.Transparent">Transparent</FluentButton>

--- a/src/Core/Components/Button/FluentButton.razor.cs
+++ b/src/Core/Components/Button/FluentButton.razor.cs
@@ -178,7 +178,7 @@ public partial class FluentButton : FluentComponentBase, ITooltipComponent
 
     /// <summary>
     /// Gets or sets the title of the button.
-    /// The text usually displayed in a `tooltip` popup when the mouse is over the button.
+    /// The text usually displayed in a `tooltip` popup on mouse hovering or keyboard focus.
     /// </summary>
     [Parameter]
     public string? Title { get; set; }


### PR DESCRIPTION
- Add tooltip to button example
- Change Title (tooltip) comment to indicate is shows on keyboard focus as well.
