### PR TITLE
[SortableList] Extend the CSS class with more predefined variables

### DIFF
--- a/examples/Demo/Shared/Pages/SortableList/SortableListPage.razor
+++ b/examples/Demo/Shared/Pages/SortableList/SortableListPage.razor
@@ -14,9 +14,17 @@
 <code>
     <pre>
     .fluent-sortable-list {
-         --fluent-sortable-list-background-color: var(--neutral-layer-2);
-         --fluent-sortable-list-item-height: calc(var(--design-unit) * 8px);
-         --fluent-sortable-list-filtered: var(--warning);
+        --fluent-sortable-list-background-color: var(--neutral-layer-2);
+        --fluent-sortable-list-item-height: calc(var(--design-unit) * 8px);
+        --fluent-sortable-list-filtered: var(--warning);
+        --fluent-sortable-list-border-width: calc(var(--stroke-width) * 1px);
+        --fluent-sortable-list-border-color: var(--neutral-stroke-input-active);
+        --fluent-sortable-list-padding: calc(var(--design-unit) * 1px);
+        --fluent-sortable-list-item-border-width: calc(var(--stroke-width) * 1px);
+        --fluent-sortable-list-item-border-color: var(--neutral-stroke-input-active);
+        --fluent-sortable-list-item-drop-border-color: var(--accent-fill-rest);
+        --fluent-sortable-list-item-drop-color: var(--neutral-layer-1);
+        --fluent-sortable-list-item-padding: 0 calc(var(--design-unit) * 2px);
     }
     </pre>
 </code>

--- a/src/Core/Components/SortableList/FluentSortableList.razor.css
+++ b/src/Core/Components/SortableList/FluentSortableList.razor.css
@@ -8,9 +8,17 @@
     --fluent-sortable-list-background-color: var(--neutral-layer-2);
     --fluent-sortable-list-item-height: calc(var(--design-unit) * 8px);
     --fluent-sortable-list-filtered: var(--warning);
-    border: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-input-active);
+    --fluent-sortable-list-border-width: calc(var(--stroke-width) * 1px);
+    --fluent-sortable-list-border-color: var(--neutral-stroke-input-active);
+    --fluent-sortable-list-padding: calc(var(--design-unit) * 1px);
+    --fluent-sortable-list-item-border-width: calc(var(--stroke-width) * 1px);
+    --fluent-sortable-list-item-border-color: var(--neutral-stroke-input-active);
+    --fluent-sortable-list-item-drop-border-color: var(--accent-fill-rest);
+    --fluent-sortable-list-item-drop-color: var(--neutral-layer-1);
+    --fluent-sortable-list-item-padding: 0 calc(var(--design-unit) * 2px);
+    border: var(--fluent-sortable-list-border-width) solid var(--fluent-sortable-list-border-color);
     border-radius: calc(var(--control-corner-radius) * 1px);
-    padding: calc(var(--design-unit) * 1px);
+    padding: var(--fluent-sortable-list-padding);
     min-height: var(--fluent-sortable-list-item-height);
 }
 
@@ -43,13 +51,13 @@
     align-items: center;
     height: var(--fluent-sortable-list-item-height) !important;
     background-color: var(--fluent-sortable-list-background-color);
-    border: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-input-active);
+    border: var(--fluent-sortable-list-item-border-width) solid var(--fluent-sortable-list-item-border-color);
     border-radius: calc(var(--control-corner-radius) * 1px);
     -moz-user-select: none;
     -ms-user-select: none;
     -webkit-user-select: none;
     user-select: none;
-    padding: 0 calc(var(--design-unit) * 2px);
+    padding: var(--fluent-sortable-list-item-padding);
     margin-bottom: 2px;
 }
 
@@ -58,12 +66,12 @@
     }
 
 .fluent-sortable-list ::deep .sortable-ghost > .sortable-item-content {
-    background-color: var(--neutral-layer-1) !important;
+    background-color: var(--fluent-sortable-list-item-drop-color) !important;
 }
 
 .fluent-sortable-list ::deep .sortable-ghost {
-    background: var(--neutral-layer-1) !important;
-    border: calc(var(--stroke-width) * 1px) dotted var(--accent-fill-rest) !important;
+    background: var(--fluent-sortable-list-item-drop-color) !important;
+    border: calc(var(--stroke-width) * 1px) dotted var(--fluent-sortable-list-item-drop-border-color) !important;
 }
 
 .fluent-sortable-list > .sortable-item:is(.filtered) {


### PR DESCRIPTION

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
A proposal to add a few new predefined variables to the `FluentSortableList.css` to allow greater customization of both the list itself and its individual list items.

I've been using the `FluentSortableList` component and it works great but I've got some visual requirements which are beyond the simple text based sortable items on the demo site. I'm currently working on a Kanban board which uses bespoke cards inside the `FluentSortableList` template component. 

I've made use of the already supplied `--fluent-sortable-list-item-height` and `--fluent-sortable-list-background-color` predefined variables but found I need finer control of the items themselves, not just the list container as each individual item has its own border, border color and padding which can only be removed/changed by overriding CSS selectors as highlighted by @vnbaaij in a [question](https://github.com/microsoft/fluentui-blazor/discussions/3871#discussioncomment-13376865) I asked earlier today.

I've added a selection of predefined variables which allow more control over how the list looks by default and when dragging/dropping list items so they can be easily added directly inside razor files to each individual component. 

```
    --fluent-sortable-list-border-width: calc(var(--stroke-width) * 1px);
    --fluent-sortable-list-border-color: var(--neutral-stroke-input-active);
    --fluent-sortable-list-padding: calc(var(--design-unit) * 1px);
    --fluent-sortable-list-item-border-width: calc(var(--stroke-width) * 1px);
    --fluent-sortable-list-item-border-color: var(--neutral-stroke-input-active);
    --fluent-sortable-list-item-drop-border-color: var(--accent-fill-rest);
    --fluent-sortable-list-item-drop-color: var(--neutral-layer-1);
    --fluent-sortable-list-item-padding: 0 calc(var(--design-unit) * 2px);
```

I've actually used the `FluentSortableList` component quite a bit in my project but never used it in the style outlined on the demo site and I think these added options greatly increase the flexibility of the component itself. I've almost always got another Fluent or bespoke component type inside which doesn't need extraneous padding, or borders. I think anyone else using the component with any content other than basic text or slightly different style requirements might find these useful rather than managing CSS overrides for specific list components.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
