### PR TITLE
[DesignTheme] Only write data-theme when mode is changed

### DIFF
--- a/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.js
+++ b/src/Core/Components/DesignSystemProvider/FluentDesignTheme.razor.js
@@ -3,7 +3,9 @@ export function addThemeChangeEvent(dotNetHelper, id) {
 
     if (element) {
         element.addEventListener("onchange", (e) => {
-            UpdateBodyDataSetTheme(e.detail.newValue);
+            if (e.detail.name === "mode") {
+                UpdateBodyDataSetTheme(e.detail.newValue);
+            }
             try {
                 // setTimeout: https://github.com/dotnet/aspnetcore/issues/26809
                 setTimeout(() => {
@@ -28,7 +30,7 @@ export function addThemeChangeEvent(dotNetHelper, id) {
             ClearLocalStorage(id);
             console.error(`FluentDesignTheme: failing to load theme from localStorage.`, error);
         }
-       
+
     }
 
     return null;


### PR DESCRIPTION
Add an extra check so the body data-theme only gets updated when the mode is changed. Fix #4082 