### PR TITLE
[InputFile] Remove .ToArray as it is not necessary

### DIFF
--- a/src/Core/Components/InputFile/FluentInputFile.razor.cs
+++ b/src/Core/Components/InputFile/FluentInputFile.razor.cs
@@ -361,7 +361,7 @@ public partial class FluentInputFile : FluentComponentBase, IAsyncDisposable
 
         if (OnCompleted.HasDelegate)
         {
-            await OnCompleted.InvokeAsync(uploadedFiles.ToArray());
+            await OnCompleted.InvokeAsync(uploadedFiles);
         }
     }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR removes the `ToArray` call for the `OnCompleted` event callback which is not necessary. This saves a few allocations for the copied array.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
