### PR TITLE
[dev-v5] Update the asterisk required symbol

### DIFF
--- a/src/Core/Components/Field/FluentField.razor
+++ b/src/Core/Components/Field/FluentField.razor
@@ -25,10 +25,6 @@ else
                    style="@LabelStyle">
                 @Parameters.Label
                 @Parameters.LabelTemplate
-                @if (Parameters.Required == true)
-                {
-                    <span class="asterisk" aria-hidden="true" />
-                }
             </label>
         }
 

--- a/src/Core/Components/Field/FluentField.razor.css
+++ b/src/Core/Components/Field/FluentField.razor.css
@@ -8,15 +8,6 @@ fluent-field[label-position='before'] > fluent-label[slot='label'] {
   align-self: flex-start;
 }
 
-fluent-field .asterisk {
-  color: var(--colorPaletteRedForeground1);
-  margin-inline-start: var(--spacingHorizontalXS)
-}
-
-  fluent-field .asterisk::before {
-    content: '*';
-  }
-
 fluent-field label[disabled] {
   color: var(--colorNeutralForegroundDisabled);
 }

--- a/tests/Core/Components/List/FluentComboboxTests.FluentCombobox_Label.verified.razor.html
+++ b/tests/Core/Components/List/FluentComboboxTests.FluentCombobox_Label.verified.razor.html
@@ -1,7 +1,6 @@
 
 <fluent-field id="xxx" label-position="above" class="my-3-o">
   <label id="xxx" slot="label" for="xxx" required="">List of digits
-    <span class="asterisk" aria-hidden="true"></span>
   </label>
   <fluent-dropdown id="xxx" slot="input" required="" type="combobox" blazor:ondropdownchange="1" blazor:onfocusout="2">
     <fluent-listbox>

--- a/tests/Core/Components/List/FluentSelectTests.FluentSelect_Label.verified.razor.html
+++ b/tests/Core/Components/List/FluentSelectTests.FluentSelect_Label.verified.razor.html
@@ -2,7 +2,6 @@
 <fluent-field id="xxx" label-position="above" class="my-3-o">
   <label id="xxx" slot="label" for="xxx" required="">
     List of digits
-    <span class="asterisk" aria-hidden="true"></span>
   </label>
   <fluent-dropdown id="xxx" slot="input" required="" type="dropdown" blazor:ondropdownchange="1" blazor:onfocusout="2">
     <fluent-listbox>


### PR DESCRIPTION
# Update the asterisk required symbol

With the latest NPM WebComponents, the required asterisk was added. So, we can now removed the temporary `<span class="asterisk" aria-hidden="true" />` 

Before
<img width="248" height="105" alt="image" src="https://github.com/user-attachments/assets/37f688b8-96cf-4223-ba7f-e3b9dd28944f" />

After
<img width="247" height="96" alt="image" src="https://github.com/user-attachments/assets/20e2e3a1-e56c-4c24-8bbb-110caa49812e" />


## Unit Tests

Updated