### PR TITLE
[dev-v5] Add DateTime extension methods documentation

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DateTime/FluentDateTime.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DateTime/FluentDateTime.md
@@ -21,6 +21,22 @@ Navigate to this [page](/DateTime/Calendar) for more details.
 
 {{ CalendarDefault }}
 
+## DatePicker
+
+Navigate to this [page](/DateTime/DatePicker) for more details.
+
+{{ DatePickerDefault }}
+
+## TimePicker
+
+Navigate to this [page](/DateTime/TimePicker) for more details.
+
+{{ TimePickerDefault }}
+
+## Extensions
+
+Navigate to this [page](/DateTime/Extensions) for more details.
+
 ## Minimum and Maximum dates
 
 The minimum selectable date is the 1st of February 0001 and the maximum selectable date is the 31st of December 9999.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DateTime/ToTimeAgo/DateTimeExtensions.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DateTime/ToTimeAgo/DateTimeExtensions.md
@@ -1,0 +1,46 @@
+---
+title: Extensions
+order: 0004
+route: /DateTime/Extensions
+---
+
+# DateTime Extensions
+
+## ToTimeAgo()
+
+An extension method `ToTimeAgo(TimeSpan delay)` returns a string with one of these samples, depending of the delay.
+
+ - Just now
+ - 25 seconds ago
+ - 14 minutes ago
+ - 9 hours ago
+ - 1 day ago
+ - 5 days ago
+ - 6 months ago
+ - 2 years ago
+
+Example
+
+```csharp
+var delay = TimeSpan.FromMinutes(5);
+
+// 5 minutes ago
+var message = delay.ToTimeAgo();
+```
+
+> [!NOTE] You can localize these strings using an optional `localizer` argument.
+> By default, English is used.
+> See the [Localization](/localization) page to create your custom localizer.
+> **TimeAgo** resource constants are prefixed with `TimeAgo_` and are provided for both singular and plural phrases.
+> Example: `Localization.LanguageResource.TimeAgo_YearAgo` and `Localization.LanguageResource.TimeAgo_YearsAgo`.
+
+## DateOnly, TimeOnly bindings
+
+In some situations, you may want to use a `DatePicker.Value` parameter of type `DateTime?`,
+but you only have data of type `DateOnly` or `TimeOnly`.
+In this case, you can use the `ToDateTime`, `ToDateTimeNullable`, `ToDateOnly`, `ToDateOnlyNullable`,
+`ToTimeOnly` or `ToTimeOnlyNullable` extension methods.
+
+Example
+
+{{ TimePickerToDateOnly }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DateTime/ToTimeAgo/Examples/TimePickerToDateOnly.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DateTime/ToTimeAgo/Examples/TimePickerToDateOnly.razor
@@ -1,0 +1,54 @@
+﻿@using Microsoft.FluentUI.AspNetCore.Components.Extensions
+
+<!-- Default usage -->
+<FluentDatePicker TValue="DateTime?"
+                  @bind-Value="@MyDate0" />
+<FluentTimePicker TValue="DateTime?"
+                  @bind-Value="@MyTime0" />
+<b>Date:</b> @(MyDate0?.ToString("yyyy-MM-dd"))
+<b>Time:</b> @(MyTime0?.ToString("HH:mm"))
+<br />
+
+<!-- Using conversion methods -->
+<FluentDatePicker TValue="DateTime?"
+                  Value="@MyDate1"
+                  ValueChanged="@(e => MyDate1 = e.ToDateTime())" />
+<FluentTimePicker TValue="DateTime?"
+                  Value="@MyTime1"
+                  ValueChanged="@(e => MyTime1 = e.ToDateTime())" />
+<b>Date:</b> @(MyDate1.ToString("yyyy-MM-dd"))
+<b>Time:</b> @(MyTime1.ToString("HH:mm"))
+<br />
+
+<FluentDatePicker TValue="DateTime?"
+                  Value="@MyDate2.ToDateTimeNullable()"
+                  ValueChanged="@(e => MyDate2 = e.ToDateOnlyNullable())" />
+<FluentTimePicker TValue="DateTime?"
+                  Value="@MyTime2.ToDateTimeNullable()"
+                  ValueChanged="@(e => MyTime2 = e.ToTimeOnlyNullable())" />
+<b>Date:</b> @(MyDate2?.ToString("yyyy-MM-dd"))
+<b>Time:</b> @(MyTime2?.ToString("HH:mm"))
+<br />
+
+<FluentDatePicker TValue="DateTime?"
+                  Value="@MyDate3.ToDateTime()"
+                  ValueChanged="@(e => MyDate3 = e.ToDateOnly())" />
+<FluentTimePicker TValue="DateTime?"
+                  Value="@MyTime3.ToDateTime()"
+                  ValueChanged="@(e => MyTime3 = e.ToTimeOnly())" />
+<b>Date:</b> @(MyDate3.ToString("yyyy-MM-dd"))
+<b>Time:</b> @(MyTime3.ToString("HH:mm"))
+<br />
+
+@code
+{
+    private DateTime? MyDate0 = DateTime.Now;
+    private DateTime MyDate1 = DateTime.Now;
+    private DateOnly? MyDate2 = DateOnly.FromDateTime(DateTime.Now);
+    private DateOnly MyDate3 = DateOnly.FromDateTime(DateTime.Now);
+
+    private DateTime? MyTime0 = DateTime.Now;
+    private DateTime MyTime1 = DateTime.Now;
+    private TimeOnly? MyTime2 = TimeOnly.FromDateTime(DateTime.Now);
+    private TimeOnly MyTime3 = TimeOnly.FromDateTime(DateTime.Now);
+}


### PR DESCRIPTION
# [dev-v5] Add DateTime extension methods documentation

## ToTimeAgo()

An extension method `ToTimeAgo(TimeSpan delay)` returns a string with one of these samples, depending of the delay.

 - Just now
 - 25 seconds ago
 - 14 minutes ago
 - 9 hours ago
 - 1 day ago
 - 5 days ago
 - 6 months ago
 - 2 years ago

Example

```csharp
var delay = TimeSpan.FromMinutes(5);

// 5 minutes ago
var message = delay.ToTimeAgo();
```

## DateOnly, TimeOnly bindings

In some situations, you may want to use a `DatePicker.Value` parameter of type `DateTime?`,
but you only have data of type `DateOnly` or `TimeOnly`.
In this case, you can use the `ToDateTime`, `ToDateTimeNullable`, `ToDateOnly`, `ToDateOnlyNullable`,
`ToTimeOnly` or `ToTimeOnlyNullable` extension methods.

