### PR TITLE
[dev-v5] Update the Icons Explorers for deployments

### DIFF
--- a/examples/Demo/FluentUI.Explorers/Components/App.razor
+++ b/examples/Demo/FluentUI.Explorers/Components/App.razor
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
+    <link rel="icon" href="data:," />
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["FluentUI.Explorers.styles.css"]" />
     <ImportMap />

--- a/examples/Demo/FluentUI.Explorers/Components/Pages/EmojiExplorer.razor
+++ b/examples/Demo/FluentUI.Explorers/Components/Pages/EmojiExplorer.razor
@@ -1,4 +1,5 @@
 ﻿@page "/emoji-explorer"
+@page "/emoji-explorer/embedded"
 @inherits ExplorerBase
 
 <PageTitle>FluentUI Blazor - Emojis explorer</PageTitle>

--- a/examples/Demo/FluentUI.Explorers/Components/Pages/IconExplorer.razor
+++ b/examples/Demo/FluentUI.Explorers/Components/Pages/IconExplorer.razor
@@ -1,4 +1,5 @@
-﻿@page "/icon-explorer"  
+﻿@page "/icon-explorer"
+@page "/icon-explorer/embedded"
 @inherits ExplorerBase
 
 <PageTitle>FluentUI Blazor - Icons explorer</PageTitle>

--- a/examples/Demo/FluentUI.Explorers/ReadMe.md
+++ b/examples/Demo/FluentUI.Explorers/ReadMe.md
@@ -18,37 +18,18 @@ of the Fluent UI Blazor library.
    dotnet publish "FluentUI.Explorers.csproj" -c Release -o ./bin/Publish -f net9.0
    ```
 
-## Update the Web.Config
-
-To allow an external site to embed your site in an iframe,
-you need to add a [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) item
-the following to the generated ´web.config` file:
-
-```xml
-<configuration>
-  ...
-  <system.webServer>
-    <httpProtocol>
-      <customHeaders>
-        <remove name="X-Frame-Options" />
-        <add name="Content-Security-Policy" value="frame-ancestors 'self' https://localhost:7026 https://fluentui-blazor.net https://www.fluentui-blazor.net https://fluentui-blazor-v5.azurewebsites.net" />
-      </customHeaders>
-    </httpProtocol>
-  </system.webServer>
-  ...
-</configuration>
-```
-
-## Deploy in Azure
-
-1. Compress the resulting folder into a ZIP file.
+4. Compress the resulting folder into a ZIP file.
 
    ```bash
    Compress-Archive ./bin/Publish/* ./bin/FluentUI-Explorers.zip
    ```
 
-2. Open Azure Portal and navigate to the Web App **fluentui-explorer** (Slot `v5`)
+## Deploy to Azure
 
-3. Use the Development **Tools / Advanced Tools** to drop the Zip file in the root folder.
+1. Open Azure Portal and navigate to the Web App **fluentui-explorer** (Slot `v5`)
+   Use the Development **Tools / Advanced Tools** to drop the Zip file
+   in the `site/wwwroot` folder.
 
-4. Check the deployment: https://fluentui-explorer-v5.azurewebsites.net
+   https://fluentui-explorer-v5.scm.azurewebsites.net/DebugConsole
+
+2. Check the deployment: https://fluentui-explorer-v5.azurewebsites.net


### PR DESCRIPTION
# [dev-v5] Update the Icons Explorers for deployments

Update the readme and URLs so that they are compatible with the v4 and v5 documentation websites.