### PR TITLE
[AccordionItem] Add HeadingTooltip parameter

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -55,6 +55,15 @@
             Gets or sets a callback when a accordion item is changed.
             </summary>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAccordionItem.LibraryConfiguration">
+            <summary />
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAccordionItem.JSRuntime">
+            <summary />
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAccordionItem.Module">
+            <summary />
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAccordionItem.Owner">
             <summary>
             Gets or sets the owning FluentTreeView.
@@ -72,6 +81,11 @@
             Gets or sets the heading content of the accordion item.
             Use either this or the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentAccordionItem.Heading"/> parameter."/>
             If both are set, this parameter will not be used.
+            </summary>
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAccordionItem.HeadingTooltip">
+            <summary>
+            Gets or sets the tooltip for the heading of the accordion item.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentAccordionItem.Expanded">

--- a/examples/Demo/Shared/Pages/Accordion/Examples/AccordionDefault.razor
+++ b/examples/Demo/Shared/Pages/Accordion/Examples/AccordionDefault.razor
@@ -10,10 +10,10 @@
         </div>
         Panel two content, using the 'end' slot for extra header content
     </FluentAccordionItem>
-    <FluentAccordionItem Expanded="true" Heading="Panel three">
+	<FluentAccordionItem Expanded="true" Heading="Panel three" HeadingTooltip="My heading 3 tooltip">
         Panel three content
     </FluentAccordionItem>
-    <FluentAccordionItem Expanded="true">
+    <FluentAccordionItem Expanded="true" HeadingTooltip="My heading 4 tooltip">
         <HeadingTemplate>
             Panel <span style="color:red">Four</span>
         </HeadingTemplate>

--- a/src/Core/Components/Accordion/FluentAccordionItem.razor.js
+++ b/src/Core/Components/Accordion/FluentAccordionItem.razor.js
@@ -1,0 +1,7 @@
+export function setControlAttribute(id, attrName, value) {
+    const fieldElement = document.querySelector("#" + id)?.shadowRoot?.querySelector("[part='button']");
+
+    if (!!fieldElement) {
+        fieldElement?.setAttribute(attrName, value);
+    }
+}

--- a/tests/Core/Accordion/FluentAccordionItemTests.FluentAccordionItem_WithHeadingAndTooltip.verified.html
+++ b/tests/Core/Accordion/FluentAccordionItemTests.FluentAccordionItem_WithHeadingAndTooltip.verified.html
@@ -1,0 +1,4 @@
+
+<fluent-accordion-item id="xxx" blazor:onaccordionchange="1" b-d6xo7qntdj="" blazor:elementreference="xxx">
+  <span slot="heading" b-d6xo7qntdj="">custom heading value</span>
+</fluent-accordion-item>

--- a/tests/Core/Accordion/FluentAccordionItemTests.FluentAccordionItem_WithHeadingTemplateAndTooltip.verified.html
+++ b/tests/Core/Accordion/FluentAccordionItemTests.FluentAccordionItem_WithHeadingTemplateAndTooltip.verified.html
@@ -1,0 +1,4 @@
+
+<fluent-accordion-item id="xxx" blazor:onaccordionchange="1" b-d6xo7qntdj="" blazor:elementreference="xxx">
+  <div slot="heading" b-d6xo7qntdj="">custom heading content</div>
+</fluent-accordion-item>

--- a/tests/Core/Accordion/FluentAccordionItemTests.cs
+++ b/tests/Core/Accordion/FluentAccordionItemTests.cs
@@ -3,17 +3,32 @@
 // ------------------------------------------------------------------------
 
 using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Accordion;
 
-public class FluentAccordionItemTests : TestBase
+public class FluentAccordionItemTests : TestContext
 {
+    private const string FluentAccordionItemRazorJs = "./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Accordion/FluentAccordionItem.razor.js";
+
+    [Inject]
+    private LibraryConfiguration LibraryConfiguration { get; set; } = new LibraryConfiguration();
+
+    public FluentAccordionItemTests()
+    {
+        var script = JSInterop.SetupModule(FluentAccordionItemRazorJs);
+        script.SetupVoid("setControlAttribute", _ => true);
+
+        Services.AddSingleton(LibraryConfiguration.ForUnitTests);
+    }
+
     [Fact]
     public void FluentAccordionItem_WithChildContent_IsNull()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>();
+        var cut = RenderComponent<FluentAccordionItem>();
 
         // Assert
         cut.Verify();
@@ -23,7 +38,7 @@ public class FluentAccordionItemTests : TestBase
     public void FluentAccordionItem_WithProvided_Content()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>(parameters =>
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
         {
             parameters.AddChildContent("child content");
         });
@@ -35,8 +50,9 @@ public class FluentAccordionItemTests : TestBase
     [Fact]
     public void FluentAccordionItem_WithCustomHeaderValue()
     {
+
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>(parameters =>
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
         {
             parameters.Add(p => p.Heading, "custom heading value");
         });
@@ -49,7 +65,7 @@ public class FluentAccordionItemTests : TestBase
     public void FluentAccordionItem_WithHeadingTemplateAndHeading_IsProvidedBoth()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>(parameters =>
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
         {
             parameters.Add(p => p.HeadingTemplate, context =>
             {
@@ -63,13 +79,45 @@ public class FluentAccordionItemTests : TestBase
         cut.Verify();
     }
 
+    [Fact]
+    public void FluentAccordionItem_WithHeadingAndTooltip()
+    {
+        // Arrange & Act
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
+        {
+            parameters.Add(p => p.Heading, "custom heading value");
+            parameters.Add(p => p.HeadingTooltip, "my tooltip");
+        });
+
+        // Assert
+        cut.Verify();
+    }
+
+    [Fact]
+    public void FluentAccordionItem_WithHeadingTemplateAndTooltip()
+    {
+        // Arrange & Act
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
+        {
+            parameters.Add(p => p.HeadingTemplate, context =>
+            {
+                context.AddContent(0, "custom heading content");
+            });
+
+            parameters.Add(p => p.HeadingTooltip, "my tooltip");
+        });
+
+        // Assert
+        cut.Verify();
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public void FluentAccordionItem_WithProvidedExpanded_Parameter(bool expanded)
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>(parameters =>
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
         {
             parameters.Add(p => p.Expanded, expanded);
         });
@@ -82,7 +130,7 @@ public class FluentAccordionItemTests : TestBase
     public void FluentAccordionItem_WithAnAdditionalAttribute()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>(parameters =>
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
         {
             parameters.AddUnmatched("unknown", "unknowns-value");
         });
@@ -95,7 +143,7 @@ public class FluentAccordionItemTests : TestBase
     public void FluentAccordionItem_WithMultipleAdditionalAttributes()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>(parameters =>
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
         {
             parameters.AddUnmatched("unknown1", "unknown1s-value");
             parameters.AddUnmatched("unknown2", "unknown2s-value");
@@ -109,7 +157,7 @@ public class FluentAccordionItemTests : TestBase
     public void FluentAccordionItem_WhenAllParamsAdded_AndAdditionalAttributes_AndContent()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>(parameters =>
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
         {
             parameters.Add(p => p.Expanded, true);
             parameters.Add(p => p.Heading, "custom heading value");
@@ -126,7 +174,7 @@ public class FluentAccordionItemTests : TestBase
     public void FluentAccordionItem_WhenAdditionalCSSClass_IsProvided()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>(parameters =>
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
         {
             parameters.Add(p => p.Class, "additional-class");
         });
@@ -139,7 +187,7 @@ public class FluentAccordionItemTests : TestBase
     public void FluentAccordionItem_WhenAdditionalStyle_IsProvided()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>(parameters =>
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
         {
             parameters.Add(p => p.Style, "background-color: grey");
         });
@@ -152,7 +200,7 @@ public class FluentAccordionItemTests : TestBase
     public void FluentAccordionItem_WithHeadingTemplate_IsNull()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>(parameters =>
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
         {
             parameters.Add(p => p.HeadingTemplate, context => { });
         });
@@ -165,7 +213,7 @@ public class FluentAccordionItemTests : TestBase
     public void FluentAccordionItem_WithHeadingTemplate_IsProvided()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordionItem>(parameters =>
+        var cut = RenderComponent<FluentAccordionItem>(parameters =>
         {
             parameters.Add(p => p.HeadingTemplate, context =>
             {

--- a/tests/Core/Accordion/FluentAccordionTests.cs
+++ b/tests/Core/Accordion/FluentAccordionTests.cs
@@ -3,17 +3,23 @@
 // ------------------------------------------------------------------------
 
 using Bunit;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Accordion;
 
-public class FluentAccordionTests : TestBase
+public class FluentAccordionTests : TestContext
 {
+    public FluentAccordionTests()
+    {
+        Services.AddSingleton(LibraryConfiguration.ForUnitTests);
+    }
+
     [Fact]
     public void FluentAccordion_When_ChildContent_IsNull()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordion>();
+        var cut = RenderComponent<FluentAccordion>();
 
         // Assert
         cut.Verify();
@@ -23,7 +29,7 @@ public class FluentAccordionTests : TestBase
     public void FluentAccordion_TheDefaultExpandMode_WhenExpandMode_IsNotSpecified()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordion>();
+        var cut = RenderComponent<FluentAccordion>();
 
         // Assert
         cut.Verify();
@@ -35,7 +41,7 @@ public class FluentAccordionTests : TestBase
     public void FluentAccordion_WhenExpandMode_IsSpecified(AccordionExpandMode accordionExpandMode)
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordion>(parameters =>
+        var cut = RenderComponent<FluentAccordion>(parameters =>
         {
             parameters.Add(p => p.ExpandMode, accordionExpandMode);
         });
@@ -48,7 +54,7 @@ public class FluentAccordionTests : TestBase
     public void FluentAccordion_WhenAdditionalCSSClass_IsProvided()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordion>(parameters =>
+        var cut = RenderComponent<FluentAccordion>(parameters =>
         {
             parameters.Add(p => p.Class, "additional-class");
         });
@@ -61,7 +67,7 @@ public class FluentAccordionTests : TestBase
     public void FluentAccordion_WhenAdditionalStyle_IsProvided()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordion>(parameters =>
+        var cut = RenderComponent<FluentAccordion>(parameters =>
         {
             parameters.Add(p => p.Style, "background-color: grey");
         });
@@ -74,7 +80,7 @@ public class FluentAccordionTests : TestBase
     public void FluentAccordion_WhenAdditionalParameters_AreAdded()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordion>(parameters =>
+        var cut = RenderComponent<FluentAccordion>(parameters =>
         {
             parameters.AddUnmatched("unmatched1", "unmatched1-value");
             parameters.AddUnmatched("unmatched2", "unmatched2-value");
@@ -88,7 +94,7 @@ public class FluentAccordionTests : TestBase
     public void FluentAccordion_WhenExpandedModeIsSingle_AndMultipleItemAreExpanded_ByDefault()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordion>(parameters =>
+        var cut = RenderComponent<FluentAccordion>(parameters =>
         {
             parameters.Add(p => p.ExpandMode, AccordionExpandMode.Single);
             parameters.AddChildContent<FluentAccordionItem>(itemParams => itemParams.Add(p => p.Expanded, true));
@@ -103,14 +109,14 @@ public class FluentAccordionTests : TestBase
     public void FluentAccordion_Dispose()
     {
         // Arrange & Act
-        var cut = TestContext.RenderComponent<FluentAccordion>(parameters =>
+        var cut = RenderComponent<FluentAccordion>(parameters =>
         {
             parameters.Add(p => p.ExpandMode, AccordionExpandMode.Single);
             parameters.AddChildContent<FluentAccordionItem>(itemParams => itemParams.Add(p => p.Expanded, true));
             parameters.AddChildContent<FluentAccordionItem>(itemParams => itemParams.Add(p => p.Expanded, true));
         });
 
-        TestContext.DisposeComponents();
+        DisposeComponents();
 
         // Assert
         Assert.True(cut.IsDisposed);


### PR DESCRIPTION
This PR fixes #4305 by:
- Adding a `HeadingTooltip` parameter to `FluentAccordionItem`

The tooltip is implemented by adding a `title` attribute to the button that is rendered in the item header. Adding the `title` attribute to the `span` or `div` (when using `HeadingTemplate`) has no effect because they are inside the button and they do not receive the mouse/hover events then.
Extra tests have been added.

This probably needs to be ported to V5 as well.