### PR TITLE
[Templates] Fix .net10 web app rename issue

### DIFF
--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1/Components/App.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1/Components/App.razor
@@ -7,7 +7,7 @@
     <base href="/" />
     <ResourcePreloader />
     <link rel="stylesheet" href="@Assets["app.css"]" />
-    <link rel="stylesheet" href="@Assets["BlazorWeb-CSharp.styles.css"]" />
+    <link rel="stylesheet" href="@Assets["BlazorWebCSharp.1.styles.css"]" />
     <ImportMap />
     @*#if (SampleContent)
     <link rel="icon" type="image/png" href="favicon.png" />

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1/Components/Layout/MainLayout.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1/Components/Layout/MainLayout.razor
@@ -3,7 +3,7 @@
 @*#if (SampleContent) -->
 <FluentLayout>
     <FluentHeader>
-        BlazorWeb-CSharp
+        BlazorWebCSharp.1
     </FluentHeader>
     <FluentStack Class="main" Orientation="Orientation.Horizontal" Width="100%">
         <NavMenu />


### PR DESCRIPTION
The .net 10 Web App template had 2 references of the old project name left. These are now replaced. Fix #4308 