### PR TITLE
[Templates] Fix Client projects in Web App templates

### DIFF
--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1.Client/Program.Main.cs
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1.Client/Program.Main.cs
@@ -1,4 +1,7 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+#if (UseWebAssembly)
+using Microsoft.FluentUI.AspNetCore.Components;
+#endif
 
 namespace BlazorWebCSharp._1.Client;
 
@@ -12,8 +15,12 @@ class Program
         builder.Services.AddAuthorizationCore();
         builder.Services.AddCascadingAuthenticationState();
         builder.Services.AddAuthenticationStateDeserialization();
-
 #endif
+
+#if (UseWebAssembly)
+        builder.Services.AddFluentUIComponents();
+#endif
+
         await builder.Build().RunAsync();
     }
 }

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1.Client/Program.cs
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1.Client/Program.cs
@@ -1,4 +1,7 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+#if (UseWebAssembly)
+using Microsoft.FluentUI.AspNetCore.Components;
+#endif
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
@@ -6,6 +9,10 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.Services.AddAuthorizationCore();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddAuthenticationStateDeserialization();
-
 #endif
+
+#if (UseWebAssembly)
+builder.Services.AddFluentUIComponents();
+#endif
+
 await builder.Build().RunAsync();

--- a/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1/Components/_Imports.razor
+++ b/src/Templates/templates/blazorweb-csharp-10/BlazorWebCSharp.1/Components/_Imports.razor
@@ -14,8 +14,6 @@
 @using BlazorWebCSharp._1
 @*#if (UseWebAssembly) -->
 @using BlazorWebCSharp._1.Client
-##endif*@
-@*#if (UseServer && UseWebAssembly && InteractiveAtRoot) -->
 @using BlazorWebCSharp._1.Client.Layout
 ##endif*@
 @using BlazorWebCSharp._1.Components

--- a/src/Templates/templates/blazorweb-csharp-8/.template.config/template.json
+++ b/src/Templates/templates/blazorweb-csharp-8/.template.config/template.json
@@ -131,6 +131,7 @@
           "exclude": [
             "BlazorWeb-CSharp/Components/Account/**",
             "BlazorWeb-CSharp/Data/**",
+            "BlazorWeb-CSharp.Client/PersistentAuthenticationStateProvider.cs",
             "BlazorWeb-CSharp.Client/UserInfo.cs",
             "BlazorWeb-CSharp.Client/Pages/Auth.razor"
           ]

--- a/src/Templates/templates/blazorweb-csharp-8/BlazorWeb-CSharp.Client/Program.Main.cs
+++ b/src/Templates/templates/blazorweb-csharp-8/BlazorWeb-CSharp.Client/Program.Main.cs
@@ -3,6 +3,9 @@ using BlazorWeb_CSharp.Client;
 using Microsoft.AspNetCore.Components.Authorization;
 #endif
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+#if (UseWebAssembly)
+using Microsoft.FluentUI.AspNetCore.Components;
+#endif
 
 namespace BlazorWeb_CSharp.Client;
 
@@ -16,8 +19,12 @@ class Program
         builder.Services.AddAuthorizationCore();
         builder.Services.AddCascadingAuthenticationState();
         builder.Services.AddSingleton<AuthenticationStateProvider, PersistentAuthenticationStateProvider>();
-
 #endif
+
+#if (UseWebAssembly)
+        builder.Services.AddFluentUIComponents();
+#endif
+
         await builder.Build().RunAsync();
     }
 }

--- a/src/Templates/templates/blazorweb-csharp-8/BlazorWeb-CSharp.Client/Program.cs
+++ b/src/Templates/templates/blazorweb-csharp-8/BlazorWeb-CSharp.Client/Program.cs
@@ -3,6 +3,9 @@ using BlazorWeb_CSharp.Client;
 using Microsoft.AspNetCore.Components.Authorization;
 #endif
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+#if (UseWebAssembly)
+using Microsoft.FluentUI.AspNetCore.Components;
+#endif
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
@@ -10,6 +13,10 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.Services.AddAuthorizationCore();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddSingleton<AuthenticationStateProvider, PersistentAuthenticationStateProvider>();
-
 #endif
+
+#if (UseWebAssembly)
+builder.Services.AddFluentUIComponents();
+#endif
+
 await builder.Build().RunAsync();

--- a/src/Templates/templates/blazorweb-csharp-9/BlazorWeb-CSharp.Client/Program.Main.cs
+++ b/src/Templates/templates/blazorweb-csharp-9/BlazorWeb-CSharp.Client/Program.Main.cs
@@ -1,4 +1,7 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+#if (UseWebAssembly)
+using Microsoft.FluentUI.AspNetCore.Components;
+#endif
 
 namespace BlazorWeb_CSharp.Client;
 
@@ -12,8 +15,12 @@ class Program
         builder.Services.AddAuthorizationCore();
         builder.Services.AddCascadingAuthenticationState();
         builder.Services.AddAuthenticationStateDeserialization();
-
 #endif
+
+#if (UseWebAssembly)
+        builder.Services.AddFluentUIComponents();
+#endif
+
         await builder.Build().RunAsync();
     }
 }

--- a/src/Templates/templates/blazorweb-csharp-9/BlazorWeb-CSharp.Client/Program.cs
+++ b/src/Templates/templates/blazorweb-csharp-9/BlazorWeb-CSharp.Client/Program.cs
@@ -1,4 +1,7 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+#if (UseWebAssembly)
+using Microsoft.FluentUI.AspNetCore.Components;
+#endif
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
@@ -6,6 +9,10 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.Services.AddAuthorizationCore();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddAuthenticationStateDeserialization();
-
 #endif
+
+#if (UseWebAssembly)
+builder.Services.AddFluentUIComponents();
+#endif
+
 await builder.Build().RunAsync();


### PR DESCRIPTION
 The `Program.cs` (and `Program.Main.cs`) files were missing a using statement and the `AddFluentUIComponents()` call following choices made in the new project dialog.
Also, a file was not being removed for a certain choice when using .NET 8.

Fix #4327