### PR TITLE
[ProfileMenu] Change tabindex to 0

### DIFF
--- a/src/Core/Components/ProfileMenu/FluentProfileMenu.razor
+++ b/src/Core/Components/ProfileMenu/FluentProfileMenu.razor
@@ -1,7 +1,7 @@
 ﻿@namespace Microsoft.FluentUI.AspNetCore.Components
 @inherits FluentComponentBase
 
-<div id="@Id" class="@ClassValue" style="@StyleValue" top-corner="@TopCorner" tabindex="1"
+<div id="@Id" class="@ClassValue" style="@StyleValue" top-corner="@TopCorner" tabindex="0"
      @onclick="@ProfileMenuClickedAsync" @onkeydown="@ProfileMenuKeyDownAsync" >
     @StartTemplate
     <FluentPersona Id="@PersonaId"

--- a/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_Customized.verified.razor.html
+++ b/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_Customized.verified.razor.html
@@ -1,5 +1,5 @@
 
-<div id="xxx" class="fluent-profile-menu" tabindex="1" blazor:onclick="1" blazor:onkeydown="2" b-rsm9d6pikk="">
+<div id="xxx" class="fluent-profile-menu" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-rsm9d6pikk="">
   <div id="xxx" class="fluent-persona" style="height: inherit;" position="end" b-n7zog0zvqi="">
     <div class="initials" b-n7zog0zvqi="">
       <div class="fluent-presence-badge" title="" b-1o8tp31nhy="">

--- a/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_Default.verified.razor.html
+++ b/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_Default.verified.razor.html
@@ -1,5 +1,5 @@
 
-<div id="xxx" class="fluent-profile-menu" tabindex="1" blazor:onclick="1" blazor:onkeydown="2" b-rsm9d6pikk="">
+<div id="xxx" class="fluent-profile-menu" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-rsm9d6pikk="">
   <div id="xxx" class="fluent-persona" style="height: inherit;" position="end" b-n7zog0zvqi="">
     <div class="initials" b-n7zog0zvqi="">
       <div class="fluent-presence-badge" title="I'm available" b-1o8tp31nhy="">

--- a/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_StartEndTemplate.verified.razor.html
+++ b/tests/Core/ProfileMenu/FluentProfileMenuTests.FluentProfileMenu_StartEndTemplate.verified.razor.html
@@ -1,5 +1,5 @@
 
-<div id="xxx" class="fluent-profile-menu" tabindex="1" blazor:onclick="1" blazor:onkeydown="2" b-rsm9d6pikk="">Before
+<div id="xxx" class="fluent-profile-menu" tabindex="0" blazor:onclick="1" blazor:onkeydown="2" b-rsm9d6pikk="">Before
   <div id="xxx" class="fluent-persona" style="height: inherit;" position="end" b-n7zog0zvqi="">
     <div class="initials" b-n7zog0zvqi="">
       <div class="fluent-presence-badge" title="" b-1o8tp31nhy="">


### PR DESCRIPTION
Fix #4397. The `FluentProfileMenu` used a hard-coded `tabindex` attribute value of `1` (see #4104), This PR sets it to use `0`

PS - I did a search on the rest of the codebase. We do not use a value of `1` anywhere else.