### PR TITLE
[dev-v5] Make Title in FluentMessageBar plain text only

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentMessageBar.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationFluentMessageBar.md
@@ -9,10 +9,15 @@ hidden: true
 
 ### Renamed properties 🔃
   The `FadeIn` property has been renamed to `Animation`.
-  
+
 ### Removed properties💥
   The `IconColor` property has been removed. Use `Icon.WithColor()` method instead.
 
   The `Intent.Custom` property has been removed. Don't use the `Intent` property and set `Icon` and `ChildContent` instead to customize the message bar.
 
   The `Type` property has been removed. Use the `Layout` property instead to choose the position of the actions and to display the `TimeStamp`.
+
+### Changed properties ⚠️
+
+  The `Title` property is a string and cannot contain markup anymore. Use the `ChildContent` property to customize the title content.
+  Example: `<ChildContent><span class="title">Customized <b>title</b></span></ChildContent>`  

--- a/src/Core/Components/MessageBar/FluentMessageBar.razor
+++ b/src/Core/Components/MessageBar/FluentMessageBar.razor
@@ -19,7 +19,7 @@
 
             @if (!string.IsNullOrEmpty(Title))
             {
-                <span class="title">@((MarkupString)Title)</span>
+                <span class="title">@Title</span>
             }
         </AddTag>
 

--- a/src/Core/Components/MessageBar/FluentMessageBar.razor.cs
+++ b/src/Core/Components/MessageBar/FluentMessageBar.razor.cs
@@ -70,6 +70,8 @@ public partial class FluentMessageBar : FluentComponentBase
 
     /// <summary>
     /// Gets or sets the most important info to be shown in the message bar.
+    /// You cannot format this string using HTML tags (bold, italic, etc.).
+    /// If you need to format the content, use the <see cref="ChildContent"/> parameter.
     /// </summary>
     [Parameter]
     public string? Title { get; set; }


### PR DESCRIPTION
# [dev-v5] Make Title in FluentMessageBar plain text only

Migration from #4414 

The `Title` parameter now accepts **only plain strings** and no HTML markup. 
For custom or formatted titles, use the `ChildContent` parameter. 

Example
```xml
<ChildContent>
   <span class="title">Customized <b>title</b></span>
</ChildContent>
```

Updated code and docs to clarify usage and provide examples.

