### PR TITLE
[General] Apply fix for using latest SDKs when publishing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,32 +2,32 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <RuntimeVersion8>8.0.0</RuntimeVersion8>
-    <AspNetCoreVersion8>8.0.20</AspNetCoreVersion8>
-    <EfCoreVersion8>8.0.20</EfCoreVersion8>
-    <RuntimeVersion9>9.0.9</RuntimeVersion9>
-    <AspNetCoreVersion9>9.0.9</AspNetCoreVersion9>
-    <EfCoreVersion9>9.0.9</EfCoreVersion9>
-    <RuntimeVersion10>10.0.0</RuntimeVersion10>
-    <AspNetCoreVersion10>10.0.0</AspNetCoreVersion10>
-    <EfCoreVersion10>10.0.0</EfCoreVersion10>
+    <AspNetCoreVersion8>8.0.22</AspNetCoreVersion8>
+    <EfCoreVersion8>8.0.22</EfCoreVersion8>
+    <RuntimeVersion9>9.0.11</RuntimeVersion9>
+    <AspNetCoreVersion9>9.0.11</AspNetCoreVersion9>
+    <EfCoreVersion9>9.0.11</EfCoreVersion9>
+    <RuntimeVersion10>10.0.1</RuntimeVersion10>
+    <AspNetCoreVersion10>10.0.1</AspNetCoreVersion10>
+    <EfCoreVersion10>10.0.1</EfCoreVersion10>
   </PropertyGroup>
   <ItemGroup>
     <!-- For Sample Apps -->
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" version="4.12.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.12.1" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" version="4.13.2" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.13.2" />
     <!-- Test dependencies -->
     <PackageVersion Include="bunit" Version="1.38.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-    <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <!-- Shared dependencies -->
-    <PackageVersion Include="Markdig.Signed" Version="0.41.3" />
+    <PackageVersion Include="Markdig.Signed" Version="0.44.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.OData.Client" Version="8.4.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.OData.Client" Version="8.4.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
   </ItemGroup>

--- a/global.bak
+++ b/global.bak
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.305",
+    "version": "9.0.308",
     "allowPrerelease": true,
     "rollForward": "latestPatch"
   }

--- a/global.json.local
+++ b/global.json.local
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.205",
+    "version": "9.0.308",
     "allowPrerelease": false,
     "rollForward": "disable"
   }

--- a/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
+++ b/src/Core/Microsoft.FluentUI.AspNetCore.Components.csproj
@@ -105,4 +105,23 @@
       <LastGenOutput>%(ParentFile).Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+
+  <!-- Temporary fix for problem with .esproj files when using latest SDKs. Will be fully fixed in later SDK -->
+  <Target Name="FixEsprojOriginalItemSpec"
+           AfterTargets="ResolveReferencedProjectsStaticWebAssets"
+           Condition="'@(StaticWebAsset)' != ''">
+    <ItemGroup>
+      <_EsprojAssetsToFix Include="@(StaticWebAsset)"
+                          Condition="$([System.String]::new('%(StaticWebAsset.OriginalItemSpec)').EndsWith('.esproj'))" />
+    </ItemGroup>
+    <ItemGroup Condition="'@(_EsprojAssetsToFix)' != ''">
+      <StaticWebAsset Remove="@(_EsprojAssetsToFix)" />
+      <StaticWebAsset Include="@(_EsprojAssetsToFix)">
+        <OriginalItemSpec>%(Identity)</OriginalItemSpec>
+      </StaticWebAsset>
+    </ItemGroup>
+    <ItemGroup>
+      <_EsprojAssetsToFix Remove="@(_EsprojAssetsToFix)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
There was a change introduced in the SDKs after 9.0.205 that lead to the contents of the `.esproj` file being served in the browser instead of the script contents. This issue has now been addressed and will be fixed in a later SDK. In the meantime we have been provided with a workaround which is implemented in this PR

More information [about the issue](https://github.com/dotnet/sdk/issues/50987) and [about the PR that fixes it](https://github.com/dotnet/sdk/pull/52283)


- Add fix for .esproj contents being served with later .NET SDKs
- Update NuGet packages
