### PR TITLE
[dev-v5] Hide popover host when not opened using CSS

### DIFF
--- a/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
+++ b/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
@@ -28,6 +28,10 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
       // Set initial styles for the dialog
       const sheet = new CSSStyleSheet();
       sheet.replaceSync(`
+            :host(:not([opened='true'])) {
+                display: none;
+            }
+
             :host div[fuib][popover] {
                 position: fixed;
                 margin: 0;


### PR DESCRIPTION
# [dev-v5] Hide popover host when not opened using CSS

This pull request enhances the visibility control of the popover component by updating its stylesheet to conditionally display the host element based on the opened attribute.

- FluentPopover.ts: Added a CSS rule to hide the host element unless opened="true" is set.
