### PR TITLE
[dev-v5] Fix broken css selector in reboot

### DIFF
--- a/src/Core/wwwroot/css/reboot.css
+++ b/src/Core/wwwroot/css/reboot.css
@@ -16,7 +16,7 @@
 
 
 @media (prefers-reduced-motion: no-preference) {
-  : root {
+  :root {
     scroll-behavior: smooth;
   }
 }
@@ -357,9 +357,9 @@ legend {
   line-height: inherit;
 }
 
-legend + * {
-  clear: left;
-}
+  legend + * {
+    clear: left;
+  }
 
 ::-webkit-datetime-edit-fields-wrapper,
 ::-webkit-datetime-edit-text,


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes a broken CSS selector in `reboot.css` for smooth scrolling

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
