### PR TITLE
[dev-v5] Hide navigation in mobile layout

### DIFF
--- a/src/Core/Components/Layout/FluentLayoutItem.razor.css
+++ b/src/Core/Components/Layout/FluentLayoutItem.razor.css
@@ -74,6 +74,10 @@
   line-height: var(--lineHeightBase100);
 }
 
+.fluent-layout[mobile] .fluent-layout-item[area="nav"] {
+  display: none;
+}
+
 /* For external use */
 .fluent-header-hover:hover {
   background-color: var(--colorBrandBackground);


### PR DESCRIPTION
# [dev-v5] Hide navigation in mobile layout

Fix the issue #4469:
> The navigation pane of fluent layout does not correctly disappear when below mobile breakpoint but instead is rendered in the bottom end corner after all other content of the layout.
> <img width="1261" height="571" alt="image" src="https://github.com/user-attachments/assets/aed85fab-14af-4892-aba1-6324b3a2bd02" />
