### PR TITLE
[dev-v5] Add support for nested popovers and related event handling

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Popover/Examples/FluentPopoverNested.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Popover/Examples/FluentPopoverNested.razor
@@ -1,5 +1,5 @@
 ﻿<FluentButton Id="Nested1" OnClick="@(e => Opened1 = !Opened1)">Open Popover</FluentButton>
-<FluentPopover AnchorId="Nested1" @bind-Opened="@Opened1">
+<FluentPopover Nested="true" AnchorId="Nested1" @bind-Opened="@Opened1">
     <p>Popover Level 1 content</p>
 
     <FluentButton Id="Nested2" OnClick="@(e => Opened2 = !Opened2)">Open Level 2</FluentButton>

--- a/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
+++ b/src/Core.Scripts/src/Components/Popover/FluentPopover.ts
@@ -24,6 +24,14 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
       this.dialog.setAttribute('fuib', '');
       this.dialog.setAttribute('popover', '');
       this.dialog.setAttribute('part', 'dialog');    // To allow styling using `fluent-popover-b::part(dialog)`
+      
+      // Dispatch the toggle event when the popover is opened or closed
+      // For nested popovers, the event is dispatched during showPopover/closePopover methods
+      this.dialog.addEventListener('toggle', (e) => {
+        if (!this.nested) {
+          this.dispatchOpenedEvent(e.newState === 'open');
+        }
+      });
 
       // Set initial styles for the dialog
       const sheet = new CSSStyleSheet();
@@ -138,6 +146,11 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
       return val !== null ? Number(val) : 0;
     }
 
+    private get nested(): boolean {
+      const val = this.getAttribute('nested');
+      return val !== null && val !== 'false';
+    }
+
     /* ****************/
     /* Show or Close  */
     /* ****************/
@@ -156,9 +169,12 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
 
       // Reflect opened property and attribute
       this.opened = true;
-
-      // Dispatch event when shown
-      this.dispatchOpenedEvent(true);
+      
+      // Dispatch event when shown.
+      // For non-nested popovers, the event is dispatched by the Popover component itself.
+      if (this.nested) {
+        this.dispatchOpenedEvent(true);
+      }
     }
 
     public closePopover() {
@@ -169,9 +185,12 @@ export namespace Microsoft.FluentUI.Blazor.Components.Popover {
 
         // Reflect opened property and attribute
         this.opened = false;
-
+        
         // Dispatch event when closed
-        this.dispatchOpenedEvent(false);
+        // For non-nested popovers, the event is dispatched by the Popover component itself.
+        if (this.nested) {
+          this.dispatchOpenedEvent(false);
+        }
       }
     }
 

--- a/src/Core/Components/Popover/FluentPopover.razor
+++ b/src/Core/Components/Popover/FluentPopover.razor
@@ -8,6 +8,7 @@
                   offset-vertical="@(OffsetVertical != 0 ? OffsetVertical : null)"
                   offset-horizontal="@(OffsetHorizontal != 0 ? OffsetHorizontal : null)"
                   opened="@(Opened ? "true" : "false")"
+                  nested="@(Nested ? "true" : null)"
                   @attributes="@AdditionalAttributes"
                   @ondialogtoggle="@OnToggleAsync">
     @ChildContent

--- a/src/Core/Components/Popover/FluentPopover.razor.cs
+++ b/src/Core/Components/Popover/FluentPopover.razor.cs
@@ -76,6 +76,12 @@ public partial class FluentPopover : FluentComponentBase
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the popover is nested inside another popover.
+    /// </summary>
+    [Parameter]
+    public bool Nested { get; set; }
+
     /// <summary />
     internal async Task OnToggleAsync(DialogToggleEventArgs args)
     {

--- a/tests/Core/Components/Popover/FluentPopoverTests.razor
+++ b/tests/Core/Components/Popover/FluentPopoverTests.razor
@@ -74,6 +74,16 @@
         Assert.Contains("style=\"height: 100px;\"", cut.Markup);
     }
 
+    [Fact]
+    public void FluentPopover_Nested()
+    {
+        // Arrange
+        var cut = Render(@<FluentPopover AnchorId="MyButton" Nested="true">Popover Content</FluentPopover>);
+
+        // Assert
+        Assert.Contains("nested=\"true\"", cut.Markup);
+    }
+
     [Theory]
     [InlineData("MyPopover", "open", true)]
     [InlineData("MyPopover", "closed", false)]

--- a/tests/Core/Components/TextArea/FluentTextAreaTests.razor
+++ b/tests/Core/Components/TextArea/FluentTextAreaTests.razor
@@ -138,6 +138,8 @@
     [InlineData(true, 0, "new value", "new value")]     // With Immediate and Delay = 0 ms
     public async Task FluentTextArea_OnImmediate(bool immediate, int immediateDelay, string expectedImmediateValue, string expectedDelayedValue)
     {
+        await Task.CompletedTask;
+        
         // Arrange
         using var context = new IdentifierContext(i => "myId");
         var value = "init";

--- a/tests/Core/Components/TextInput/FluentTextInputTests.razor
+++ b/tests/Core/Components/TextInput/FluentTextInputTests.razor
@@ -153,6 +153,8 @@
     [InlineData(true, 0, "new value", "new value")]     // With Immediate and Delay = 0 ms
     public async Task FluentInputText_OnImmediate(bool immediate, int immediateDelay, string expectedImmediateValue, string expectedDelayedValue)
     {
+        await Task.CompletedTask;
+        
         // Arrange
         using var context = new IdentifierContext(i => "myId");
         var value = "init";


### PR DESCRIPTION
# [dev-v5] Add support for nested popovers and related event handling

- Use the default `ontoggle` HTML event
- Add a new parameter `nested` to close a popover only when the user clicks outside the elements.

## Unit Tests

Validated (100%)