### PR TITLE
Fix notification center demo issues

### DIFF
--- a/examples/Demo/Shared/Components/NotificationCenterPanel.razor
+++ b/examples/Demo/Shared/Components/NotificationCenterPanel.razor
@@ -5,9 +5,12 @@
 
     <FluentStack>
         <FluentSpacer />
-        <FluentAnchor Appearance="@Appearance.Hypertext" Href="" OnClick="@(e => MessageService.Clear(App.MESSAGES_NOTIFICATION_CENTER) )">
-            Dismiss all
-        </FluentAnchor>
+		@if (MessageService.Count(App.MESSAGES_NOTIFICATION_CENTER) > 0)
+		{
+			<FluentAnchor Appearance="@Appearance.Hypertext" Href="#" OnClick="@(e => MessageService.Clear(App.MESSAGES_NOTIFICATION_CENTER))">
+				Dismiss all
+			</FluentAnchor>
+		}
     </FluentStack>
 
     <br />


### PR DESCRIPTION
Fix #4492

This pull request makes a small but important change to the `NotificationCenterPanel.razor` component. Now, the "Dismiss all" link will only be shown if there are notifications present in the notification center, improving the user experience by hiding unnecessary actions. Also, the link does not redirect to the homepage anymore.

- UI improvement:
  * Updated `NotificationCenterPanel.razor` so that the "Dismiss all" anchor is only rendered when there are notifications to dismiss.