### PR TITLE
Fix typo in Badge documentation for SourceCode parameter

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Badges/Badge/FluentBadge.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Badges/Badge/FluentBadge.md
@@ -19,7 +19,7 @@ A badge can be attached to any content. The default position is above-end. The p
 
 The `OffsetX` and `OffsetY` allow for tuning the positioning further.
 
-{{ BadgeAttached SourcCode=false }}
+{{ BadgeAttached SourceCode=false }}
 
 ## Colors
 The badge colors be set to a value from the `BadgeColor` enumeration. The last badge shows how a custom background color can be used.


### PR DESCRIPTION


# Pull Request

## 📖 Description

This pull request contains a minor update to the documentation for the `BadgeAttached` component. The change corrects a typo in the usage of the component tag to ensure proper rendering of the documentation example.

* Fixed a typo in the `BadgeAttached` component tag by renaming the `SourcCode` parameter to `SourceCode` in `FluentBadge.md`.

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing docs
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps
