### PR TITLE
[dev-v5] [Docs] Update keycode docs to reflect latest interface

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/KeyCode/FluentKeyCode.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/KeyCode/FluentKeyCode.md
@@ -45,10 +45,7 @@ protected override void OnInitialized()
     KeyCodeService.RegisterListener(OnKeyDownAsync);
 }
 
-public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args)
-{
-    // ...
-}
+public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args) => { // ... }
 
 public ValueTask DisposeAsync()
 {
@@ -70,15 +67,9 @@ public partial MyPage : IKeyCodeListener, IAsyncDisposable
         KeyCodeService.RegisterListener(this);
     }
 
-    public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args)
-    {
-        // ...
-    }
+    public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args) => { // ... }
 
-    public async Task OnKeyUpAsync(FluentKeyCodeEventArgs args)
-    {
-        // ...
-    }
+    public async Task OnKeyUpAsync(FluentKeyCodeEventArgs args) => { // ... }
 
     public ValueTask DisposeAsync()
     {

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/KeyCode/FluentKeyCode.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/KeyCode/FluentKeyCode.md
@@ -45,7 +45,10 @@ protected override void OnInitialized()
     KeyCodeService.RegisterListener(OnKeyDownAsync);
 }
 
-public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args) => { // ... }
+public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args)
+{
+    // ...
+}
 
 public ValueTask DisposeAsync()
 {
@@ -57,7 +60,7 @@ public ValueTask DisposeAsync()
 **Either**, implementing the interface **IKeyCodeListener**, retrieving the service and registering the method that will capture the keys:
 
 ```csharp
-public partial MyPage : IKeyCodeListener, IDisposableAsync
+public partial MyPage : IKeyCodeListener, IAsyncDisposable
 {
     [Inject]
     private IKeyCodeService KeyCodeService { get; set; }
@@ -67,7 +70,15 @@ public partial MyPage : IKeyCodeListener, IDisposableAsync
         KeyCodeService.RegisterListener(this);
     }
 
-    public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args) => { // ... }
+    public async Task OnKeyDownAsync(FluentKeyCodeEventArgs args)
+    {
+        // ...
+    }
+
+    public async Task OnKeyUpAsync(FluentKeyCodeEventArgs args)
+    {
+        // ...
+    }
 
     public ValueTask DisposeAsync()
     {


### PR DESCRIPTION
Some small updates to the `FluentKeyCode` docs.

- `IDisposableAsync` has been changed to `IAsyncDisposable`
- `OnKeyUpAsync` has been added from the `IKeyCodeListener` interface
- `=>` has been removed to make the code copyable


PR for v4 is coming as well :)