### PR TITLE
Add example of standard layout to FluentLayout documentation

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Layout/FluentLayout.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Layout/FluentLayout.md
@@ -137,6 +137,75 @@ You can adapt them using the `Height` parameter of the `FluentLayout`,
 --layout-body-height: calc(var(--layout-height) - var(--layout-header-height) - var(--layout-footer-height));
 ```
 
+## Standard Layout (header, navigation and footer)
+
+This example demonstrates a classic layout commonly used in most websites. It includes a **header** at the top with a hamburger menu toggle and the application title, a collapsible **navigation panel** on the side with links to different pages, a **content** area that renders the current page body, and a **footer** at the bottom for branding or copyright information.
+
+Simply copy the code below into your Blazor **layout page** and replace the `@Body` element with this code example. That's it!
+
+<table class="layout-schema">
+  <tr>
+    <td colspan="3">Header</td>
+  </tr>
+  <tr>
+    <td>Nav</td>
+    <td colspan="2" style="width: 100%; height: 60px;">Content</td>
+  <tr>
+    <td colspan="3">Footer</td>
+  </tr>
+</table>
+
+```razor
+<FluentLayout>
+
+    <!-- Header -->
+    <FluentLayoutItem Area="@LayoutArea.Header">
+        <FluentStack VerticalAlignment="VerticalAlignment.Center">
+            <FluentLayoutHamburger />
+            <FluentText Weight="TextWeight.Bold"
+                        Size="TextSize.Size400">
+                My application
+            </FluentText>
+        </FluentStack>
+    </FluentLayoutItem>
+
+    <!-- Navigation -->
+    <FluentLayoutItem Area="@LayoutArea.Navigation"
+                      Width="250px">
+
+        <FluentNav Padding="@Padding.All2"
+                   Style="height: 100%;">
+            <FluentNavItem Href="/"
+                           Match="NavLinkMatch.All"
+                           IconRest="@(new Icons.Regular.Size20.Home())">
+                Home
+            </FluentNavItem>
+            <FluentNavItem Href="/counter"
+                           IconRest="@(new Icons.Regular.Size20.RemixAdd())">
+                Counter
+            </FluentNavItem>
+            <FluentNavItem Href="/weather"
+                           IconRest="@(new Icons.Regular.Size20.WeatherRainShowersDay())">
+                Weather
+            </FluentNavItem>
+        </FluentNav>
+
+    </FluentLayoutItem>
+
+    <!-- Content -->
+    <FluentLayoutItem Area="@LayoutArea.Content"
+                      Padding="@Padding.All3">
+        @Body
+    </FluentLayoutItem>
+
+    <!-- Footer -->
+    <FluentLayoutItem Area="@LayoutArea.Footer">
+        Powered by Microsoft Fluent UI Blazor @DateTime.Now.Year
+    </FluentLayoutItem>
+
+</FluentLayout>
+```
+
 ## API FluentLayout
 
 {{ API Type=FluentLayout }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Installation.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Installation.md
@@ -152,3 +152,4 @@ Add this code to a Razor page to verify that the installation is correct.
 Before diving into components, it's recommended to explore
 the [FluentLayout](/layout) documentation to understand project structure and layout strategies.
 
+On [this FluentLayout section](/layout#standard-layout-header-navigation-and-footer), you will find an example of a ready-to-use layout.


### PR DESCRIPTION
# Add example of standard layout to FluentLayout documentation

This example demonstrates a classic layout commonly used in most websites. It includes a **header** at the top with a hamburger menu toggle and the application title, a collapsible **navigation panel** on the side with links to different pages, a **content** area that renders the current page body, and a **footer** at the bottom for branding or copyright information.

Simply copy the code below into your Blazor **layout page** and replace the `@Body` element with this code example. That's it!

<img width="387" height="179" alt="{6F84B36C-E115-4C74-86DD-9FD0F550016C}" src="https://github.com/user-attachments/assets/c18aa52e-ffc8-4cc1-9107-621755ad25bf" />
