### PR TITLE
Fix index.ts section causing "Illegal constructor" on older iOS devices

### DIFF
--- a/src/Core.Assets/src/index.ts
+++ b/src/Core.Assets/src/index.ts
@@ -32,8 +32,6 @@ interface FluentUIEventType {
   type: string;
 }
 
-var styleSheet = new CSSStyleSheet();
-
 const styles = `
 body:has(.prevent-scroll) {
     overflow: hidden;
@@ -85,9 +83,16 @@ fluent-number-field:not([disabled]):active::after
 }
 `;
 
-styleSheet.replaceSync(styles);
-// document.adoptedStyleSheets.push(styleSheet);
-document.adoptedStyleSheets = [...document.adoptedStyleSheets, styleSheet];
+if (document.adoptedStyleSheets) {
+  const styleSheet = new CSSStyleSheet();
+  styleSheet.replaceSync(styles);
+  document.adoptedStyleSheets = [...document.adoptedStyleSheets, styleSheet];
+}
+else {
+  let style = document.createElement('style');
+  style.innerHTML = styles;
+  document.head.appendChild(style);
+}
 
 var beforeStartCalled = false;
 var afterStartedCalled = false;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Similarly to #1520, added handling for browsers that don't support `CSSStyleSheet()` constructor to index.ts. Adds feature detection around `document.adoptedStyleSheets` and falls back to injecting a `<style>` element when constructable stylesheets are unavailable. This follows the same approach used in #1520 (related to #1481).

### 🎫 Issues

Related to #1481

## 👩‍💻 Reviewer Notes

Change is limited to `index.ts` and only affects stylesheet injection logic. It caused the website to not render at all on any device running iOS 16.3 or older (can be tested on the same project demo website), logging a `Illegal constructor` error.

Recommend verifying:
- Styles still apply correctly in modern browsers
- No runtime errors occur on older iOS/Safari versions

## 📑 Test Plan

- Tested in a modern browser (constructable stylesheet path)
- Verified fallback logic on iPad running iPadOS 16.3.1
- Confirmed demo site renders, styles are applied correctly, and no errors occur in both paths
- All provided unit tests pass successfully

## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps