### PR TITLE
[dev-v5] Fix MCP server.json versioning process by implementing inline task fo…

### DIFF
--- a/src/Tools/McpServer/Microsoft.FluentUI.AspNetCore.McpServer.csproj
+++ b/src/Tools/McpServer/Microsoft.FluentUI.AspNetCore.McpServer.csproj
@@ -60,8 +60,7 @@
   <!-- Include README and MCP server manifest in package -->
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
-    <None Include=".mcp\server.json" />
-    <None Include="$(IntermediateOutputPath)$(NetVersion)\.mcp\server.json" Pack="true" PackagePath=".mcp\" />
+    <None Include=".mcp\server.json" Pack="true" PackagePath=".mcp\" />
     <None Include="..\..\..\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
@@ -180,32 +179,49 @@
   </Target>
 
   <!--
-    Target to update version in server.json before packing.
-    This copies server.json to intermediate directory and replaces version placeholders.
+    Inline task for reliable version replacement in server.json.
+    Uses C# code to read, regex-replace, and write the file preserving formatting.
   -->
-  <Target Name="UpdateMcpServerJsonVersion" BeforeTargets="BeforeBuild" Condition="'$(TargetFramework)' == '$(NetVersion)'">
+  <UsingTask TaskName="ReplaceVersionInJsonFile" TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <SourceFile ParameterType="System.String" Required="true" />
+      <DestinationFile ParameterType="System.String" Required="true" />
+      <NewVersion ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs">
+        var content = System.IO.File.ReadAllText(SourceFile);
+        content = System.Text.RegularExpressions.Regex.Replace(
+            content,
+            @"""version"":\s*""[^""]*""",
+            $@"""version"": ""{NewVersion}""");
+        var dir = System.IO.Path.GetDirectoryName(DestinationFile);
+        if (!string.IsNullOrEmpty(dir) &amp;&amp; !System.IO.Directory.Exists(dir))
+            System.IO.Directory.CreateDirectory(dir);
+        System.IO.File.WriteAllText(DestinationFile, content);
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <!--
+    Target to stamp version in .mcp/server.json before build and pack.
+    Replaces all "version": "..." entries with the current $(Version) in-place.
+    The source file uses "0.0.1" as a placeholder; the actual version is set during build.
+    Runs once per build (for the primary target framework only).
+    In CI, the working tree is disposable. For local Release builds, use 'git checkout' to restore.
+  -->
+  <Target Name="UpdateMcpServerJsonVersion" BeforeTargets="BeforeBuild"
+          Condition="'$(TargetFramework)' == '$(NetVersion)' AND '$(Configuration)' == 'Release'">
     <PropertyGroup>
-      <McpServerJsonSource>$(MSBuildThisFileDirectory).mcp\server.json</McpServerJsonSource>
-      <McpServerJsonTarget>$(IntermediateOutputPath).mcp\server.json</McpServerJsonTarget>
+      <McpServerJsonPath>$(MSBuildThisFileDirectory).mcp\server.json</McpServerJsonPath>
     </PropertyGroup>
 
-    <MakeDir Directories="$(IntermediateOutputPath).mcp" />
+    <ReplaceVersionInJsonFile SourceFile="$(McpServerJsonPath)"
+                              DestinationFile="$(McpServerJsonPath)"
+                              NewVersion="$(Version)" />
 
-    <!-- Read the source file -->
-    <ReadLinesFromFile File="$(McpServerJsonSource)">
-      <Output TaskParameter="Lines" ItemName="McpServerJsonLines" />
-    </ReadLinesFromFile>
-
-    <!-- Replace version in each line and write to target -->
-    <ItemGroup>
-      <McpServerJsonLinesUpdated Include="@(McpServerJsonLines)">
-        <Text>$([System.Text.RegularExpressions.Regex]::Replace('%(Identity)', '"version":\s*"[^"]*"', '"version": "$(Version)"'))</Text>
-      </McpServerJsonLinesUpdated>
-    </ItemGroup>
-
-    <WriteLinesToFile File="$(McpServerJsonTarget)" Lines="@(McpServerJsonLinesUpdated->'%(Text)')" Overwrite="true" />
-
-    <Message Text="Updated server.json version to $(Version)" Importance="high" />
+    <Message Text="Updated .mcp/server.json version to $(Version)" Importance="high" />
   </Target>
 
 </Project>


### PR DESCRIPTION
# Pull Request

## 📖 Description

This pull request updates the packaging process for the MCP server by improving how the version number is injected into the `.mcp/server.json` file. The main change is replacing the previous MSBuild-based line-by-line replacement with an inline C# task that uses regular expressions for more reliable and formatting-preserving version stamping. Additionally, the packaging configuration is adjusted to ensure the correct file is included in the NuGet package.

**Build process improvements:**

* Replaced the previous MSBuild-based approach for updating the version in `.mcp/server.json` with a custom inline C# task (`ReplaceVersionInJsonFile`) that uses regex to update the version in-place, preserving file formatting and improving reliability.

**Packaging configuration:**

* Updated the `ItemGroup` in `Microsoft.FluentUI.AspNetCore.McpServer.csproj` to ensure the correct `.mcp/server.json` file is included in the NuGet package, removing the unnecessary intermediate output path entry.

### 🎫 Issues

During the release compilation, the version replacement task makes the server.json file incorrect.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
