### PR TITLE
[Popover] Allow tabbing inside open anchored regions, support keyboard accessible navigation for popover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,3 +413,5 @@ Microsoft.Fast.Components.FluentUI.xml
 /tests/TemplateValidation/**/Data/*
 /spelling.dic
 
+# Mac temporary files
+*.DS_Store

--- a/src/Core/Components/AnchoredRegion/FluentAnchoredRegion.razor.js
+++ b/src/Core/Components/AnchoredRegion/FluentAnchoredRegion.razor.js
@@ -33,6 +33,143 @@ export function goToNextFocusableElement(forContainer, toOriginal, delay) {
 }
 
 
+// ---------------------------------------------------------------------------
+// Shared keyboard navigation for anchor+popup pairs (popovers, menus, etc.)
+// Implements the standard 4-case ARIA keyboard pattern:
+//   1. Tab on anchor          → focus first element in popup (stay open)
+//   2. Shift+Tab on popup     → focus anchor, close popup
+//   3. Tab on popup           → focus next page element after anchor, close popup
+//   4. Escape on popup        → focus anchor, close popup
+//   (Shift+Tab on anchor while popup open → close popup, browser handles focus)
+// ---------------------------------------------------------------------------
+
+const keyboardNavigationState = new Map();
+
+/**
+ * Attaches keyboard navigation listeners to an anchor+popup pair.
+ * @param {string} anchorId - Id of the anchor element.
+ * @param {string} popupId - Id of the popup/overlay element.
+ * @param {object} dotNetHelper - DotNetObjectReference; must expose CloseAsync().
+ * @param {number[]} closeKeyCodes - Additional key codes (besides Tab) that close the popup. Defaults to [27] (Escape).
+ */
+export function initializeKeyboardNavigation(anchorId, popupId, dotNetHelper, closeKeyCodes = [27], tabExitsAlways = false) {
+    disposeKeyboardNavigation(anchorId);
+
+    const popupElement = document.getElementById(popupId);
+    const anchorElement = document.getElementById(anchorId);
+
+    if (!popupElement || !anchorElement) {
+        return;
+    }
+
+    // Listeners on the popup content (cases 2, 3, 4)
+    const popupKeydownListener = function (ev) {
+        const keyCode = ev.which || ev.keyCode;
+        const isCloseKey = closeKeyCodes.includes(keyCode);
+
+        if (ev.key !== "Tab" && !isCloseKey) return;
+
+        if (isCloseKey) {
+            // Case 4: close key → return focus to anchor, close
+            ev.preventDefault();
+            ev.stopPropagation();
+            anchorElement.focus();
+            dotNetHelper.invokeMethodAsync('CloseAsync');
+            return;
+        }
+
+        // Tab / Shift+Tab
+        if (tabExitsAlways) {
+            // Menu pattern: Tab on any element exits immediately
+            ev.preventDefault();
+            ev.stopPropagation();
+            if (!ev.shiftKey) {
+                // Case 3: move to element after anchor in page
+                let startFrom;
+                if (anchorElement.tagName.startsWith("FLUENT-") && anchorElement.shadowRoot?.children.length > 0) {
+                    startFrom = anchorElement.shadowRoot.children[0];
+                } else {
+                    startFrom = anchorElement;
+                }
+                new FocusableElement(anchorElement.getRootNode()).findNextFocusableElement(startFrom)?.focus();
+            } else {
+                // Case 2: Shift+Tab → focus anchor
+                anchorElement.focus();
+            }
+            dotNetHelper.invokeMethodAsync('CloseAsync');
+        } else {
+            // Popover pattern: only intercept Tab at the first/last boundary;
+            // let the browser handle Tab naturally for elements in between.
+            const focusables = new FocusableElement(popupElement).getFocusableElements();
+            const activeIndex = focusables.indexOf(document.activeElement);
+
+            if (!ev.shiftKey && (focusables.length === 0 || activeIndex === focusables.length - 1)) {
+                // Case 3: Tab on last element → next page element after anchor, close
+                ev.preventDefault();
+                ev.stopPropagation();
+                let startFrom;
+                if (anchorElement.tagName.startsWith("FLUENT-") && anchorElement.shadowRoot?.children.length > 0) {
+                    startFrom = anchorElement.shadowRoot.children[0];
+                } else {
+                    startFrom = anchorElement;
+                }
+                new FocusableElement(anchorElement.getRootNode()).findNextFocusableElement(startFrom)?.focus();
+                dotNetHelper.invokeMethodAsync('CloseAsync');
+            } else if (ev.shiftKey && (focusables.length === 0 || activeIndex === 0)) {
+                // Case 2: Shift+Tab on first element → focus anchor, close
+                ev.preventDefault();
+                ev.stopPropagation();
+                anchorElement.focus();
+                dotNetHelper.invokeMethodAsync('CloseAsync');
+            }
+            // Otherwise: middle element — let browser handle Tab/Shift+Tab naturally
+        }
+    };
+
+    // Listener on the anchor (case 1 and Shift+Tab-while-open)
+    const anchorKeydownListener = function (ev) {
+        if (ev.key !== "Tab") return;
+
+        if (!ev.shiftKey) {
+            // Case 1: Tab on anchor → focus first focusable element in popup
+            const firstFocusable = new FocusableElement(popupElement).findNextFocusableElement();
+            if (!firstFocusable) return;
+
+            firstFocusable.focus();
+            ev.preventDefault();
+            ev.stopPropagation();
+        } else {
+            // Shift+Tab on anchor while popup open → close, browser handles focus naturally
+            dotNetHelper.invokeMethodAsync('CloseAsync');
+        }
+    };
+
+    popupElement.addEventListener("keydown", popupKeydownListener);
+    anchorElement.addEventListener("keydown", anchorKeydownListener);
+
+    keyboardNavigationState.set(anchorId, {
+        popupKeydownListener,
+        anchorKeydownListener,
+        popupElement,
+        anchorElement
+    });
+}
+
+/**
+ * Removes keyboard navigation listeners registered by initializeKeyboardNavigation.
+ * @param {string} anchorId
+ */
+export function disposeKeyboardNavigation(anchorId) {
+    const state = keyboardNavigationState.get(anchorId);
+    if (!state) return;
+
+    const { popupKeydownListener, anchorKeydownListener, popupElement, anchorElement } = state;
+    popupElement.removeEventListener("keydown", popupKeydownListener);
+    anchorElement.removeEventListener("keydown", anchorKeydownListener);
+
+    keyboardNavigationState.delete(anchorId);
+}
+
 /**
  * Focusable Element
  */
@@ -57,46 +194,52 @@ export class FocusableElement {
     }
 
     /**
-     * Find the next focusable element, after the optional current element, in the specified container.
-     * @param container
-     * @param currentElement
-     * @returns
+     * Returns all focusable elements within the container, resolving Fluent web component shadow roots.
+     * @returns {Element[]}
      */
-    findNextFocusableElement(currentElement) {
-        // Fluent web components may have children that are focusable, but they are not
-        // focusable themselves. Thus, we unfortunately need to query every element or provide
-        // a list of all fluent elements that have focusable children.
+    getFocusableElements() {
         const queriedElements = Array.from(this._container.querySelectorAll("*")).filter(el => {
             return el.matches(this.FOCUSABLE_SELECTORS) || el.tagName.toLowerCase().startsWith("fluent-");
         });
 
         const focusableElements = [];
-
-        // If an element is a fluent web component and is not focusable, replace with its inner focusable element
-        // if one exists.
-        queriedElements.forEach((el, index) => {
+        queriedElements.forEach(el => {
             if (el.tagName.toLowerCase().startsWith("fluent-") && el.tabIndex === -1 && !!el.shadowRoot) {
                 Array.from(el.shadowRoot.children).forEach(child => {
                     if (child.tabIndex !== -1 && child.checkVisibility()) {
                         focusableElements.push(child);
                     }
                 });
-            }
-            else {
+            } else {
                 focusableElements.push(el);
             }
         });
 
-        // Filter out elements with tabindex="-1" and elements that are not visible
-        const filteredElements = focusableElements.filter(el => !!el && el.tabIndex !== -1 && el.checkVisibility());
+        return focusableElements.filter(el => !!el && el.tabIndex !== -1 && el.checkVisibility());
+    }
+
+    /**
+     * Find the next focusable element, after the optional current element, in the specified container.
+     * @param currentElement
+     * @param reverse - If true, find the previous focusable element instead of the next.
+     * @returns
+     */
+    findNextFocusableElement(currentElement, reverse = false) {
+        const filteredElements = this.getFocusableElements();
+
+        if (filteredElements.length === 0) {
+            return null;
+        }
 
         // Find the index of the current element
         const current = currentElement ?? document.activeElement;
         if (current != null) {
             const currentIndex = filteredElements.indexOf(current);
 
-            // Calculate the index of the next element
-            const nextIndex = (currentIndex + 1) % filteredElements.length;
+            // Calculate the index of the next (or previous) element
+            const nextIndex = reverse
+                ? (currentIndex - 1 + filteredElements.length) % filteredElements.length
+                : (currentIndex + 1) % filteredElements.length;
 
             // Return the next focusable element
             return filteredElements[nextIndex];

--- a/src/Core/Components/Menu/FluentMenu.razor.js
+++ b/src/Core/Components/Menu/FluentMenu.razor.js
@@ -42,11 +42,8 @@ export async function initialize(anchorId, menuId, menuOpen, anchoredRegionModul
         return;
     }
 
-    const FocusableElement = anchoredRegionModule
-        ? anchoredRegionModule.FocusableElement
-        : null;
-    if (!FocusableElement) {
-        throw new Error("FocusableElement not available from AnchoredRegion module");
+    if (!anchoredRegionModule) {
+        throw new Error("AnchoredRegion module is required for keyboard navigation");
     }
 
     const menuElement = document.getElementById(menuId);
@@ -57,79 +54,9 @@ export async function initialize(anchorId, menuId, menuOpen, anchoredRegionModul
         return;
     }
 
-    // We need to handle four cases to be fully accessible:
-    // 1. When Tab is pressed on the anchor, focus must be moved to the first focusable element in the menu
-    // 2. When Shift+Tab is pressed on any focusable element in the menu, focus must be moved back to the anchor. This will also close the menu.
-    // 3. When Tab is pressed on any focusable element in the menu, focus should continue to the next focusable element in the element's root. This will also close the menu.
-    // 4. When Escape is pressed on any focusable element in the menu, focus must be moved back to the anchor. This will also close the menu.
-    const menuItemKeydownListener = function (ev) {
-        if (ev.key === "Tab" || ev.key === "Escape") {
-            try {
-                ev.preventDefault && ev.preventDefault();
-                ev.stopPropagation && ev.stopPropagation();
+    anchoredRegionModule.initializeKeyboardNavigation(anchorId, menuId, dotNetHelper, undefined, true);
 
-                if (!ev.shiftKey && ev.key === "Tab") {
-                    // When Tab is pressed on a focusable element, we should continue to the next focusable element
-                    // If this element is a fluent element, we should try to find the next focusable element within the shadow DOM of the fluent element if one exists,
-                    // as that is the focusable element.
-                    let element;
-                    if (anchorElement.tagName.startsWith("FLUENT-") && anchorElement.shadowRoot && anchorElement.shadowRoot.children.length > 0) {
-                        element = anchorElement.shadowRoot.children[0];
-                    }
-                    else {
-                        element = anchorElement;
-                    }
-
-                    new FocusableElement(anchorElement.getRootNode()).findNextFocusableElement(element)?.focus();
-                }
-                else {
-                    // When Shift+Tab is pressed on a focusable element, move focus back to the anchor
-                    anchorElement.focus();
-                }
-
-                dotNetHelper.invokeMethodAsync('CloseAsync');
-            } catch (ex) {
-                console.error("Failed to focus anchor:", ex);
-            }
-        }
-    };
-
-    menuElement.addEventListener("keydown", menuItemKeydownListener);
-
-    // Add keydown listener to the anchor for Tab (no shift) to focus first element
-    const anchorKeyDownListener = function (ev) {
-        if (ev.key === "Tab") {
-            if (ev.shiftKey) {
-                dotNetHelper.invokeMethodAsync('CloseAsync');
-            }
-            else {
-                const focusableHelper = new FocusableElement(menuElement);
-                const firstFocusable = focusableHelper.findNextFocusableElement();
-
-                if (!firstFocusable) {
-                    return; // no element to attach listener to
-                }
-
-                // When Tab is pressed on the anchor, move focus to the first focusable element
-                try {
-                    firstFocusable.focus();
-                    ev.preventDefault && ev.preventDefault();
-                    ev.stopPropagation && ev.stopPropagation();
-                } catch (ex) {
-                    console.error("Failed to focus first focusable element:", ex);
-                }
-            }
-        }
-    };
-
-    anchorElement.addEventListener("keydown", anchorKeyDownListener);
-
-    menuState.set(anchorId, {
-        menuItemKeydownListener,
-        anchorKeyDownListener,
-        menuElement,
-        anchorElement
-    });
+    menuState.set(anchorId, { anchoredRegionModule });
 }
 
 // Called to cleanup listeners when component is disposed
@@ -139,9 +66,6 @@ export function dispose(anchorId) {
         return;
     }
 
-    const { menuItemKeydownListener, anchorKeyDownListener, menuElement, anchorElement } = state;
-    menuElement.removeEventListener("keydown", menuItemKeydownListener);
-    anchorElement.removeEventListener("keydown", anchorKeyDownListener);
-
+    state.anchoredRegionModule?.disposeKeyboardNavigation(anchorId);
     menuState.delete(anchorId);
 }

--- a/src/Core/Components/Popover/FluentPopover.razor
+++ b/src/Core/Components/Popover/FluentPopover.razor
@@ -3,20 +3,7 @@
 
 @if (Open)
 {
-    <FluentOverlay @bind-Visible="@Open" OnClose="@CloseAsync" Transparent=true FullScreen=true />
-    @if (CloseKeys != null && CloseKeys.Any())
-    {
-        // Button or AnchorId element
-        if (!string.IsNullOrEmpty(AnchorId))
-        {
-            <FluentKeyCode Anchor="@AnchorId" Only="@CloseAndTabKeys" OnKeyDown="@CloseOnKeyAsync" PreventDefaultOnly="@(AutoFocus ? CloseAndTabKeys : CloseKeys)" />
-        }
-        // Popover content
-        if (!string.IsNullOrEmpty(Id))
-        {
-            <FluentKeyCode Anchor="@Id" Only="@CloseAndTabKeys" OnKeyDown="@CloseOnKeyAsync" PreventDefaultOnly="@CloseAndTabKeys" />
-        }
-    }
+    <FluentOverlay @bind-Visible="@Open" OnClose="@CloseOverlayAsync" Transparent=true FullScreen=true />
     <FluentAnchoredRegion @ref="AnchoredRegion"
                           Id="@Id"
                           Anchor="@AnchorId"

--- a/src/Core/Components/Popover/FluentPopover.razor.cs
+++ b/src/Core/Components/Popover/FluentPopover.razor.cs
@@ -3,19 +3,35 @@
 // ------------------------------------------------------------------------
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.FluentUI.AspNetCore.Components.Extensions;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
+using Microsoft.JSInterop;
 
 namespace Microsoft.FluentUI.AspNetCore.Components;
 
-public partial class FluentPopover : FluentComponentBase
+public partial class FluentPopover : FluentComponentBase, IAsyncDisposable
 {
+    private const string ANCHORED_REGION_JAVASCRIPT_FILE = "./_content/Microsoft.FluentUI.AspNetCore.Components/Components/AnchoredRegion/FluentAnchoredRegion.razor.js";
+
     private FluentAnchoredRegion AnchoredRegion = default!;
+    private DotNetObjectReference<FluentPopover>? _dotNetHelper;
+    private IJSObjectReference? _anchoredRegionModule;
+    private bool _disposed;
+    private bool _previousOpen;
 
     protected string? ClassValue => new CssBuilder(Class)
         .Build();
 
     protected string? StyleValue => new StyleBuilder(Style)
         .Build();
+
+    /// <summary />
+    [Inject]
+    private LibraryConfiguration LibraryConfiguration { get; set; } = default!;
+
+    /// <summary />
+    [Inject]
+    private IJSRuntime JSRuntime { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the id of the component the popover is positioned relative to.
@@ -110,12 +126,10 @@ public partial class FluentPopover : FluentComponentBase
     public KeyCode[]? CloseKeys { get; set; } = new[] { KeyCode.Escape };
 
     /// <summary />
-    private KeyCode[] CloseAndTabKeys => CloseKeys?.Any() == true ? CloseKeys.Union(new[] { KeyCode.Tab }).ToArray() : new[] { KeyCode.Tab };
-
-    /// <summary />
     protected override void OnInitialized()
     {
-        if (CloseKeys != null && CloseKeys.Any() && string.IsNullOrEmpty(Id))
+        // Id is always needed to identify the popover content element.
+        if (string.IsNullOrEmpty(Id))
         {
             Id = Identifier.NewId();
         }
@@ -131,7 +145,47 @@ public partial class FluentPopover : FluentComponentBase
     }
 
     /// <summary />
-    protected virtual async Task CloseAsync()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _anchoredRegionModule = await JSRuntime.InvokeAsync<IJSObjectReference>("import", ANCHORED_REGION_JAVASCRIPT_FILE.FormatCollocatedUrl(LibraryConfiguration));
+            _dotNetHelper = DotNetObjectReference.Create(this);
+        }
+
+        if (!_disposed && _anchoredRegionModule is not null && Open != _previousOpen)
+        {
+            _previousOpen = Open;
+            if (Open)
+            {
+                var closeKeyCodes = CloseKeys?.Select(k => (int)k).ToArray() ?? Array.Empty<int>();
+                await _anchoredRegionModule.InvokeVoidAsync("initializeKeyboardNavigation", AnchorId, Id, _dotNetHelper, closeKeyCodes);
+            }
+            else
+            {
+                await _anchoredRegionModule.InvokeVoidAsync("disposeKeyboardNavigation", AnchorId);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Closes the popover. Called from JavaScript keyboard navigation.
+    /// </summary>
+    [JSInvokable]
+    public async Task CloseAsync()
+    {
+        Open = false;
+        if (OpenChanged.HasDelegate)
+        {
+            await OpenChanged.InvokeAsync(Open);
+        }
+        StateHasChanged();
+    }
+
+    /// <summary>
+    /// Closes the popover and returns focus to the original element (used by the overlay on outside-click).
+    /// </summary>
+    protected virtual async Task CloseOverlayAsync()
     {
         Open = false;
         if (OpenChanged.HasDelegate)
@@ -142,16 +196,33 @@ public partial class FluentPopover : FluentComponentBase
     }
 
     /// <summary />
-    protected virtual async Task CloseOnKeyAsync(FluentKeyCodeEventArgs e)
+    public async ValueTask DisposeAsync()
     {
-        if (CloseKeys != null && CloseKeys.Contains(e.Key))
+        if (_disposed)
         {
-            await CloseAsync();
+            return;
         }
 
-        if (AutoFocus && e.Key == KeyCode.Tab)
+        _disposed = true;
+        _dotNetHelper?.Dispose();
+
+        try
         {
-            await AnchoredRegion.FocusToNextElementAsync();
+            if (_anchoredRegionModule is not null)
+            {
+                await _anchoredRegionModule.InvokeVoidAsync("disposeKeyboardNavigation", AnchorId);
+                await _anchoredRegionModule.DisposeAsync();
+            }
+        }
+        catch (Exception ex) when (ex is JSDisconnectedException ||
+                                   ex is OperationCanceledException)
+        {
+            // The JSRuntime side may routinely be gone already if the reason we're disposing is that
+            // the client disconnected. This is not an error.
+        }
+        finally
+        {
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/tests/Core/_ToDo/Popover/FluentPopoverTests.cs
+++ b/tests/Core/_ToDo/Popover/FluentPopoverTests.cs
@@ -2,11 +2,18 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 using Bunit;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.FluentUI.AspNetCore.Components.Tests.Popover;
 public class FluentPopoverTests : TestBase
 {
+    public FluentPopoverTests()
+    {
+        TestContext.JSInterop.Mode = JSRuntimeMode.Loose;
+        TestContext.Services.AddSingleton(LibraryConfiguration.ForUnitTests);
+    }
+
     [Fact]
     public void FluentPopover_Default()
     {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

Investigating the previous fix for menu buttons, I noticed that I forgot to support tabbing inside the anchored region. Previously, the first tab inside the region would close the popover and focus the next element on the page. Changed behavior to tabbing working until tabbing the last focusable element inside the popover (which will close the popover and focus the next page element). 

Additionally, as mentioned in the linked issue, popovers were not keyboard accessible. The keyboard access patterns are identical for both the popover and menubutton components, so I moved the common logic to `FluentAnchoredRegion.razor.js`, and updated the `FluentPopover` component to support its use.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

Fixes #4127

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

You can manually test this by interacting with elements on /Popover and /MenuButton pages in the demo server. Click on the element just prior to the component you want to test, then tab.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [X] I have modified an existing component
- [X] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
