### PR TITLE
[Tabs] Call HandleOnTabChange when changing to a tab through the menu

### DIFF
--- a/src/Core/Components/Tabs/FluentTabs.razor.cs
+++ b/src/Core/Components/Tabs/FluentTabs.razor.cs
@@ -227,6 +227,8 @@ public partial class FluentTabs : FluentComponentBase
         {
             await OnTabSelect.InvokeAsync(ActiveTab);
         }
+
+        await HandleOnTabChangedAsync(e);
     }
 
     /// <summary />


### PR DESCRIPTION
This pull request introduces a small change to the tab change handler in `FluentTabs.razor.cs`. Now, after invoking the `OnTabSelect` event, it also calls `HandleOnTabChangedAsync`, ensuring any additional logic tied to tab changes is executed.

Fix #4549 