### PR TITLE
[dev-v5] Update caption color and remove textarea border in reboot.css

### DIFF
--- a/src/Core/wwwroot/css/reboot.css
+++ b/src/Core/wwwroot/css/reboot.css
@@ -253,7 +253,7 @@ table {
 caption {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
-  color: #6c757d;
+  color: var(--colorBrandStroke1);
   text-align: left;
 }
 
@@ -293,7 +293,6 @@ textarea {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
-  border: 1px solid black;
 }
 
 


### PR DESCRIPTION
# [dev-v5] Update caption color and remove textarea border in reboot.css

Adjust the caption color to use a CSS variable for better theming and remove the border from textareas to enhance the visual design. This change improves consistency and aesthetics across the application.

Before
<img width="178" height="66" alt="image" src="https://github.com/user-attachments/assets/4a1ddcab-b950-4efe-84df-387ea4214adc" />

After
<img width="173" height="63" alt="image" src="https://github.com/user-attachments/assets/abe42d7f-e169-4e67-8b3f-668dde01a7cb" />

Fix issue #4568