### PR TITLE
[dev-v5][Docs] Fix NOTE and WARNING sections

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/FluentDataGrid.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/FluentDataGrid.md
@@ -17,8 +17,7 @@ parameter: `DataGridDisplayMode.Grid` (default) and `DataGridDisplayMode.Table`.
 used to specify column widths in fractions. It basically provides an HTML table element with a `display: grid;` style.
 - With the `Table` mode, it uses standard HTML table elements and rendering. Column widths are best specified through the `Width` parameter on the columns.
 
-> [!NOTE]
-Specifically when using `Virtualize`, it is **highly recommended** to use the `Table` display mode as the `Grid` mode can exhibit odd scrolling behavior.
+> [!NOTE] Specifically when using `Virtualize`, it is **highly recommended** to use the `Table` display mode as the `Grid` mode can exhibit odd scrolling behavior.
 
 
 ## Accessibility

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
@@ -73,12 +73,12 @@ It is then retrieved in the `DialogResult` like in the example below.
 }
 ```
 
-> [!NOTE]
-> 1. The `FluentDialogBody` component is required to display the dialog window correctly.
-> 2. ⚠️ If you override the `OnInitializedAsync` method, **you must call** the `base.OnInitializedAsync()` method,
->    in addition to your personalized code.
->    because it configures the Header, Footer and all Action buttons.
->    E.g.: `protected override async Task OnInitializedAsync() { await base.OnInitializedAsync(); // And your code }`
+> [!NOTE] The `FluentDialogBody` component is required to display the dialog window correctly.
+>
+> ⚠️ If you override the `OnInitializedAsync` method, **you must call** the `base.OnInitializedAsync()` method,
+> in addition to your personalized code.
+> because it configures the Header, Footer and all Action buttons.
+> E.g.: `protected override async Task OnInitializedAsync() { await base.OnInitializedAsync(); // And your code }`
 
 By default, the `FluentDialogInstance` class will offer two buttons, one to validate and one to cancel (**OK** and **Cancel**).
 You can override the actions of these buttons by overriding the `OnActionClickedAsync` method.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDrawer.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDrawer.md
@@ -24,8 +24,7 @@ Once the user closes the dialog window, the `ShowDrawerAsync` method returns a `
 
 👉 See the [Dialog](/Dialog) documentation for more information.
 
-> [!NOTE]
-> The `ShowDrawerAsync` method is identical to the `ShowDialogAsync` method.
+> [!NOTE] The `ShowDrawerAsync` method is identical to the `ShowDialogAsync` method.
 > With the exception of the **default value** of the `options.Alignment` property, which is `DialogAlignment.End`.
 > And the resulting HTML code is slightly different, using a `fluent-drawer` instead of a `fluent-dialog`.
 > The visual rendering and animation of opening and closing is also different.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/MessageBar/FluentMessageBar.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/MessageBar/FluentMessageBar.md
@@ -45,8 +45,7 @@ If you want to display an Action and a TimeStamp, you can use the `ActionsTempla
 
 TODO in the next PR.
 
-> [!WARNING]
-> `FluentMessageBars` are rendered by the `<FluentProviders />`.  
+> [!WARNING] `FluentMessageBars` are rendered by the `<FluentProviders />`.  
 > This component needs to be added to the layout of your application.
 > See the [Installation page](/installation) for more information.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/SortableList/FluentSortableList.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/SortableList/FluentSortableList.md
@@ -17,7 +17,7 @@ The SortableList is a generic component that takes a list of items and an `ItemT
 Sorting/moving items within the list or between lists is handled by the component itself and does not require any code (_this is different from how
 it worked with the v4 component_). Event callbacks are available to respond on these operations but they are optional. See the [API](#api-fluentsortablelist) section for more details.
 
->[!Note]Although the SortableList is a list component, it does not share _any_ code with the other list components in our library ([Select](/Lists/Select), [ComboBox](/Lists/ComboBox), [Listbox](/Lists/Listbox)). 
+>[!Note] Although the SortableList is a list component, it does not share _any_ code with the other list components in our library ([Select](/Lists/Select), [ComboBox](/Lists/ComboBox), [Listbox](/Lists/Listbox)). 
 
 ## Accessibility support
 Although SortableJS does not come with any a11y support, the `FluentSortableList` component fully supports keyboard accessibility. The following operations can be used:

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Table/HtmlTable.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Table/HtmlTable.md
@@ -24,16 +24,15 @@ The default HTML table is a simple way to display tabular data.
 
 The `data-selectable` attribute is used to make the table rows selectable.  
 
-> [!WARNING]
-> Only CSS styles are applied, no JavaScript is involved.  
+> [!WARNING] Only CSS styles are applied, no JavaScript is involved.  
 > You need to handle the selection logic yourself, for example by using the `@onclick` event.
 
 The `data-selected` attribute is used to indicate which rows `<tr>` (or cells `<td>`) are selected.
 
 {{ HtmlTableSelectable }}
 
-> [!NOTE]
-> You can customize the styles of the selected checkbox by using CSS variables.
+> [!NOTE] You can customize the styles of the selected checkbox by using CSS variables.
+>
 > `style="--selectedCheckWidth: 28px; --selectedCheckContent: '✔';`
 
 ## No checkbox

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TreeView/FluentTreeView.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TreeView/FluentTreeView.md
@@ -23,8 +23,7 @@ If you use the `Items` property, you can also set the `ItemTemplate` property to
 With these two ways of creating a tree, using the `Text` parameter will display the text of the element, adding an ellipsis `...` if the text is too long.
 Each element also has the properties `IconStart`, `IconEnd`, and `IconAside` to display an icon to the left, right, or at the end of the text.
 
-> [!NOTE]
-> When a user clicks on an item, it is selected and expanded/collapsed if children are present.
+> [!NOTE] When a user clicks on an item, it is selected and expanded/collapsed if children are present.
 > It is not possible to open an item without selecting it (except by using the keyboard, pressing the `Enter` or `Space` key)
 > or using the `Mutiple` selection feature (see below).
 
@@ -89,8 +88,7 @@ is updated with the list of selected items.
 We recommand to set the `HideSelection` parameter to `true` to hide the default selection of the item when the `MultiSelect`
 parameter is set. This is more user-friendly and allows the user to see the selected items more clearly.
 
-> [!NOTE]
-> This **Multiple Selection** feature is only available when the `Items` parameter is used to generate the tree.
+> [!NOTE] This **Multiple Selection** feature is only available when the `Items` parameter is used to generate the tree.
 
 {{ TreeViewMultiSelect }}
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Localization.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Localization.md
@@ -44,8 +44,7 @@ Here's a step-by-step guide:
     }
     ```
 
-   > [!NOTE]   
-   > The list of keys can be found in the `Core\Microsoft.FluentUI.AspNetCore.Components\Localization\LanguageResource.resx` file.  
+   > [!NOTE] The list of keys can be found in the `Core\Microsoft.FluentUI.AspNetCore.Components\Localization\LanguageResource.resx` file.  
    > Or you can use a constant from the `Microsoft.FluentUI.AspNetCore.Components.Localization.LanguageResource` class.
    > Example: `Localization.LanguageResource.MessageBox_ButtonOk`.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Examples.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Examples.md
@@ -10,8 +10,7 @@ icon: Code
 
 This page demonstrates real-world scenarios of using the Fluent UI Blazor MCP Server with AI assistants in Visual Studio and Visual Studio Code.
 
-> [!NOTE]
-> The AI responses shown on this page are **examples only**. Actual responses from GitHub Copilot or other AI assistants **may vary** depending on:
+> [!NOTE] The AI responses shown on this page are **examples only**. Actual responses from GitHub Copilot or other AI assistants **may vary** depending on:
 > - The AI model version and its training data
 > - The context of your conversation
 > - Your workspace configuration


### PR DESCRIPTION
This PR fixes the broken `[!NOTE]` and `[!WARNING]` sections in the docs.

Before:

<img width="982" height="142" alt="grafik" src="https://github.com/user-attachments/assets/9841c511-52d4-47e5-95e7-9445830a7273" />


After:

<img width="990" height="156" alt="grafik" src="https://github.com/user-attachments/assets/c6be5cd4-976f-4ad2-b9a9-87e2595853d8" />
