### PR TITLE
[dev-v5][AppBar] Allow hidding active indicator, render active indicator when horizontal

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/AppBar/Examples/AppBarDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/AppBar/Examples/AppBarDefault.razor
@@ -5,9 +5,13 @@
 	<FluentStack Orientation="Orientation.Horizontal" HorizontalGap="10">
 		<FluentSwitch @bind-Value="_showSearch" Label="Show search in popover" />
 		<FluentSwitch @bind-Value="_vertical" @bind-Value:after="@HandleOrientationChanged" Label="@($"Show {(_vertical ? "Vertical" : "Horizontal")}")" />
+        <FluentSwitch @bind-Value="_hideBar" @bind-Value:after="@HandleHideBarChanged" Label="@($"Bar {(_hideBar ? "hidden" : "shown")}")" />
 	</FluentStack>
 	<div style="@stylevalue">
-		<FluentAppBar Orientation="@(_vertical? Orientation.Vertical: Orientation.Horizontal)" PopoverVisibilityChanged="HandlePopover" PopoverShowSearch="@_showSearch">
+		<FluentAppBar Orientation="@(_vertical? Orientation.Vertical: Orientation.Horizontal)"
+        PopoverVisibilityChanged="HandlePopover"
+        PopoverShowSearch="@_showSearch"
+        HideActiveBar="@_hideBar">
 
 			<FluentAppBarItem Href="/AppBarDefault"
 							  Match="NavLinkMatch.All"
@@ -80,6 +84,7 @@
 @code {
 	private bool _vertical = true;
 	private bool _showSearch = true;
+    private bool _hideBar = false;
 
 	private static Icon ResourcesIcon(bool active = false) =>
 		active ? new Icons.Filled.Size24.AppFolder()
@@ -107,4 +112,9 @@
 	{
 		Console.WriteLine($"Orientation changed to {(_vertical ? "vertical" : "horizontal")}");
 	}
+
+    private void HandleHideBarChanged()
+    {
+        Console.WriteLine($"{(_hideBar ? "Hiding" : "Showing")} active bar");
+    }
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/AppBar/Examples/AppBarDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/AppBar/Examples/AppBarDefault.razor
@@ -11,7 +11,7 @@
 		<FluentAppBar Orientation="@(_vertical? Orientation.Vertical: Orientation.Horizontal)"
         PopoverVisibilityChanged="HandlePopover"
         PopoverShowSearch="@_showSearch"
-        HideActiveBar="@_hideBar">
+        HideActiveIndicator="@_hideBar">
 
 			<FluentAppBarItem Href="/AppBarDefault"
 							  Match="NavLinkMatch.All"

--- a/src/Core/Components/AppBar/FluentAppBar.razor
+++ b/src/Core/Components/AppBar/FluentAppBar.razor
@@ -3,7 +3,7 @@
 @inherits FluentComponentBase
 
 <CascadingValue TValue="InternalAppBarContext" Value="@_internalAppBarContext" IsFixed="true">
-	<nav id="@Id" @attributes="AdditionalAttributes" class="@ClassValue" style="@StyleValue" role="navigation" orientation="@Orientation.ToAttributeValue()" hide-bar="@(HideActiveBar)">
+	<nav id="@Id" @attributes="AdditionalAttributes" class="@ClassValue" style="@StyleValue" role="navigation" orientation="@Orientation.ToAttributeValue()" hide-bar="@(HideActiveIndicator)">
 
 		@if (Items is null)
 		{

--- a/src/Core/Components/AppBar/FluentAppBar.razor
+++ b/src/Core/Components/AppBar/FluentAppBar.razor
@@ -3,7 +3,7 @@
 @inherits FluentComponentBase
 
 <CascadingValue TValue="InternalAppBarContext" Value="@_internalAppBarContext" IsFixed="true">
-	<nav id="@Id" @attributes="AdditionalAttributes" class="@ClassValue" style="@StyleValue" role="navigation" orientation="@Orientation.ToAttributeValue()">
+	<nav id="@Id" @attributes="AdditionalAttributes" class="@ClassValue" style="@StyleValue" role="navigation" orientation="@Orientation.ToAttributeValue()" hide-bar="@(HideActiveBar)">
 
 		@if (Items is null)
 		{

--- a/src/Core/Components/AppBar/FluentAppBar.razor.cs
+++ b/src/Core/Components/AppBar/FluentAppBar.razor.cs
@@ -62,6 +62,12 @@ public partial class FluentAppBar : FluentComponentBase
     public IEnumerable<IAppBarItem>? Items { get; set; }
 
     /// <summary>
+    /// Gets or sets whether to hide the active bar on the side/bottom of the active item.
+    /// </summary>
+    [Parameter]
+    public bool? HideActiveBar { get; set; }
+
+    /// <summary>
     /// Gets or sets the content to display (the app bar items, <see cref="FluentAppBarItem"/>).
     /// </summary>
     [Parameter]

--- a/src/Core/Components/AppBar/FluentAppBar.razor.cs
+++ b/src/Core/Components/AppBar/FluentAppBar.razor.cs
@@ -65,7 +65,7 @@ public partial class FluentAppBar : FluentComponentBase
     /// Gets or sets whether to hide the active bar on the side/bottom of the active item.
     /// </summary>
     [Parameter]
-    public bool? HideActiveBar { get; set; }
+    public bool? HideActiveIndicator { get; set; }
 
     /// <summary>
     /// Gets or sets the content to display (the app bar items, <see cref="FluentAppBarItem"/>).

--- a/src/Core/Components/AppBar/FluentAppBar.razor.css
+++ b/src/Core/Components/AppBar/FluentAppBar.razor.css
@@ -47,7 +47,7 @@
   text-align: center;
 }
 
-.fluent-appbar[orientation=vertical] .fluent-appbar-item:not([inpopover]) a.active::before {
+.fluent-appbar[orientation=vertical]:not([hide-bar]) .fluent-appbar-item:not([inpopover]) a.active::before {
   content: "";
   position: absolute;
   width: var(--appbar-active-indicator-width);
@@ -59,17 +59,32 @@
   right: unset;
 }
 
-.fluent-appbar[orientation=vertical] .fluent-appbar-item.fluent-appbar-item-local:not([inpopover]) a.active::before {
-    all: initial;
+.fluent-appbar[orientation=vertical]:not([hide-bar]) .fluent-appbar-item.fluent-appbar-item-local:not([inpopover]) a.active::before {
+  all: initial;
 }
 
-[dir='rtl'] .fluent-appbar[orientation=vertical] .fluent-appbar-item:not([inpopover]) a.active::before {
-    right:2px;
-    left: unset;
+[dir='rtl'] .fluent-appbar[orientation=vertical]:not([hide-bar]) .fluent-appbar-item:not([inpopover]) a.active::before {
+  right: 2px;
+  left: unset;
 }
 
-[dir='rtl'] .fluent-appbar[orientation=vertical] .fluent-appbar-item.fluent-appbar-item-local:not([inpopover]) a.active::before {
-    all: initial;
+[dir='rtl'] .fluent-appbar[orientation=vertical]:not([hide-bar]) .fluent-appbar-item.fluent-appbar-item-local:not([inpopover]) a.active::before {
+  all: initial;
+}
+
+.fluent-appbar[orientation=horizontal]:not([hide-bar]) .fluent-appbar-item:not([inpopover]) a.active::before {
+  content: "";
+  position: absolute;
+  height: var(--appbar-active-indicator-width);
+  width: 100%;
+  background-color: var(--colorBrandForeground1);
+  border-radius: var(--borderRadiusSmall);
+  bottom: 2px;
+
+}
+
+.fluent-appbar[orientation=horizontal]:not([hide-bar]) .fluent-appbar-item.fluent-appbar-item-local:not([inpopover]) a.active::before {
+  all: initial;
 }
 
 .fluent-appbar-item:hover svg[part="icon-rest"],

--- a/tests/Core/Components/AppBar/FluentAppBarTests.razor
+++ b/tests/Core/Components/AppBar/FluentAppBarTests.razor
@@ -212,7 +212,7 @@
     public void FluentAppBar_HideActiveBar_True()
     {
         // Arrange && Act
-        var cut = Render(@<FluentAppBar HideActiveBar="true"><div>Child content</div></FluentAppBar>);
+        var cut = Render(@<FluentAppBar HideActiveIndicator="true"><div>Child content</div></FluentAppBar>);
 
         // Assert
         var ab = cut.Find("nav");
@@ -223,7 +223,7 @@
     public void FluentAppBar_HideActiveBar_False()
     {
         // Arrange && Act
-        var cut = Render(@<FluentAppBar HideActiveBar="false"><div>Child content</div></FluentAppBar>);
+        var cut = Render(@<FluentAppBar HideActiveIndicator="false"><div>Child content</div></FluentAppBar>);
 
         // Assert
         var ab = cut.Find("nav");
@@ -528,7 +528,7 @@
 		cut.Render();
 
 		// Show popover by clicking the "More" button
-		var moreButton = cut.Find(".fluent-appbar-item[fixed]"); 
+		var moreButton = cut.Find(".fluent-appbar-item[fixed]");
 		await moreButton.ClickAsync();
 		cut.Render();
 

--- a/tests/Core/Components/AppBar/FluentAppBarTests.razor
+++ b/tests/Core/Components/AppBar/FluentAppBarTests.razor
@@ -209,6 +209,39 @@
     }
 
     [Fact]
+    public void FluentAppBar_HideActiveBar_True()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentAppBar HideActiveBar="true"><div>Child content</div></FluentAppBar>);
+
+        // Assert
+        var ab = cut.Find("nav");
+        Assert.True(ab.HasAttribute("hide-bar"));
+    }
+
+    [Fact]
+    public void FluentAppBar_HideActiveBar_False()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentAppBar HideActiveBar="false"><div>Child content</div></FluentAppBar>);
+
+        // Assert
+        var ab = cut.Find("nav");
+        Assert.False(ab.HasAttribute("hide-bar"));
+    }
+
+    [Fact]
+    public void FluentAppBar_HideActiveBar_Null()
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentAppBar><div>Child content</div></FluentAppBar>);
+
+        // Assert
+        var ab = cut.Find("nav");
+        Assert.False(ab.HasAttribute("hide-bar"));
+    }
+
+    [Fact]
     public async Task FluentAppBar_HandlePopoverKeyDownAsync_Enter()
     {
         // Arrange


### PR DESCRIPTION
This PR enhances the AppBar in the following way:
- Add `HideActiveIndicator` parameter (defaults to `null`)
Result when vertical and hidden:
<img width="248" height="820" alt="image" src="https://github.com/user-attachments/assets/9d9ebd02-fe96-41c3-9422-5a6685698dba" />

- Add rendering of active bar at the bottom when in horizontal layout
Result:
<img width="1186" height="244" alt="image" src="https://github.com/user-attachments/assets/dd124d71-5a43-4895-a433-081bdb622f6f" />
When hidden: 
<img width="1157" height="211" alt="image" src="https://github.com/user-attachments/assets/9a3ee355-7234-4a82-8150-942215e704f4" />



Default example has been extended to show this new functionality. Unit test for the new parameter have been added