### PR TITLE
[dev-v5] Remove GC.SuppressFinalize calls from Dispose methods

### DIFF
--- a/src/Core/Components/Accordion/FluentAccordionItem.razor.cs
+++ b/src/Core/Components/Accordion/FluentAccordionItem.razor.cs
@@ -156,6 +156,5 @@ public partial class FluentAccordionItem : FluentComponentBase, IDisposable
     {
         // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
         Dispose(disposing: true);
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/Core/Components/AppBar/FluentAppBarItem.razor.cs
+++ b/src/Core/Components/AppBar/FluentAppBarItem.razor.cs
@@ -140,7 +140,6 @@ public partial class FluentAppBarItem : FluentComponentBase, IAppBarItem
     public override ValueTask DisposeAsync()
     {
         Owner.Unregister(this);
-        GC.SuppressFinalize(this);
 
         return base.DisposeAsync();
     }

--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -671,7 +671,6 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>, IDisposable
     public void Dispose()
     {
         _itemsChanged.Dispose();
-        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/Core/Components/KeyCode/FluentKeyCodeProvider.razor.cs
+++ b/src/Core/Components/KeyCode/FluentKeyCodeProvider.razor.cs
@@ -62,6 +62,5 @@ public partial class FluentKeyCodeProvider : IDisposable
     {
         // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
         Dispose(disposing: true);
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/Core/Components/Nav/FluentNav.razor.cs
+++ b/src/Core/Components/Nav/FluentNav.razor.cs
@@ -155,17 +155,10 @@ public partial class FluentNav : FluentComponentBase
     }
 
     /// <inheritdoc />
-    public override async ValueTask DisposeAsync()
+    protected override async ValueTask DisposeAsync(IJSObjectReference jsModule)
     {
         NavigationManager.LocationChanged -= OnLocationChanged;
-
-        if (JSModule.ObjectReference is not null)
-        {
-            await JSModule.ObjectReference.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Nav.Dispose", Id);
-        }
-
-        await base.DisposeAsync();
-        GC.SuppressFinalize(this);
+        await jsModule.InvokeVoidAsync("Microsoft.FluentUI.Blazor.Nav.Dispose", Id);
     }
 
     /// <summary>

--- a/src/Core/Components/Nav/FluentNavBase.cs
+++ b/src/Core/Components/Nav/FluentNavBase.cs
@@ -47,7 +47,6 @@ public abstract class FluentNavBase : FluentComponentBase
         Owner.Unregister(this);
 
         await base.DisposeAsync();
-        GC.SuppressFinalize(this);
     }
 
     /// <summary>

--- a/src/Core/Components/Nav/FluentNavCategory.razor.cs
+++ b/src/Core/Components/Nav/FluentNavCategory.razor.cs
@@ -107,7 +107,6 @@ public partial class FluentNavCategory : FluentNavBase
         Owner.UnregisterCategory(this);
 
         await base.DisposeAsync();
-        GC.SuppressFinalize(this);
     }
     /// <summary>
     /// Called after the component has been rendered.

--- a/src/Core/Components/Nav/FluentNavItem.razor.cs
+++ b/src/Core/Components/Nav/FluentNavItem.razor.cs
@@ -256,6 +256,5 @@ public partial class FluentNavItem : FluentNavBase
         }
 
         await base.DisposeAsync();
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/Core/Components/Overflow/FluentOverflowItem.razor.cs
+++ b/src/Core/Components/Overflow/FluentOverflowItem.razor.cs
@@ -85,6 +85,5 @@ public partial class FluentOverflowItem : FluentComponentBase, IAsyncDisposable
         Owner?.UnregisterAsync(this);
         await base.DisposeAsync();
 
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/Core/Components/Radio/FluentRadio.razor.cs
+++ b/src/Core/Components/Radio/FluentRadio.razor.cs
@@ -129,6 +129,5 @@ public partial class FluentRadio<TValue> : FluentComponentBase, IDisposable
     {
         // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
         Dispose(disposing: true);
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/Core/Components/SortableList/FluentSortableList.razor.cs
+++ b/src/Core/Components/SortableList/FluentSortableList.razor.cs
@@ -12,12 +12,10 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// A sortable list component that allows users to reorder items via drag-and-drop.
 /// <typeparam name="TItem">The type of the items in the list.</typeparam>
 /// </summary>
-public partial class FluentSortableList<TItem> : FluentComponentBase, IAsyncDisposable
+public partial class FluentSortableList<TItem> : FluentComponentBase
 {
     private ElementReference? _element;
     private DotNetObjectReference<FluentSortableList<TItem>>? _selfReference;
-    private IJSObjectReference? _jsHandle;
-    private bool _disposed;
 
     /// <summary />
     public FluentSortableList(LibraryConfiguration configuration) : base(configuration)
@@ -132,11 +130,7 @@ public partial class FluentSortableList<TItem> : FluentComponentBase, IAsyncDisp
         if (firstRender)
         {
             _selfReference = DotNetObjectReference.Create(this);
-
-            if (!_disposed)
-            {
-                _jsHandle = await JSRuntime.InvokeAsync<IJSObjectReference>("Microsoft.FluentUI.Blazor.Components.SortableList.Initialize", _element, Group, Clone ? "clone" : null, Drop, Sort, Handle ? ".sortable-grab" : null, Filter, Fallback, _selfReference);
-            }
+            await JSRuntime.InvokeAsync<IJSObjectReference>("Microsoft.FluentUI.Blazor.Components.SortableList.Initialize", _element, Group, Clone ? "clone" : null, Drop, Sort, Handle ? ".sortable-grab" : null, Filter, Fallback, _selfReference);
         }
     }
 
@@ -231,29 +225,10 @@ public partial class FluentSortableList<TItem> : FluentComponentBase, IAsyncDisp
         }
     }
 
-    /// <summary />
-    public override async ValueTask DisposeAsync()
+    /// <inheritdoc />
+    protected override async ValueTask DisposeAsync(IJSObjectReference jsModule)
     {
-        if (_disposed)
-        {
-            return;
-        }
-
-        try
-        {
-            if (_jsHandle is not null)
-            {
-                await _jsHandle.InvokeVoidAsync("stop");
-                await _jsHandle.DisposeAsync();
-            }
-        }
-        catch (Exception ex) when (ex is JSDisconnectedException or OperationCanceledException)
-        {
-            // The circuit was disconnected or the task was canceled - we're disposing anyway
-        }
-
+        await jsModule.InvokeVoidAsync("stop");
         _selfReference?.Dispose();
-        _disposed = true;
-        await base.DisposeAsync();
     }
 }


### PR DESCRIPTION
# [dev-v5] Remove GC.SuppressFinalize calls from Dispose methods

1. Eliminate redundant calls to `GC.SuppressFinalize` in various `Dispose` methods to streamline resource management. 
This change improves code clarity and adheres to best practices for implementing the IDisposable pattern.

1. Overrides the 'DisposeAsync(IJSObjectReference jsModule)' method when it is necessary to call a JS function during the removal process.