### PR TITLE
[dev-v5][DataGrid] width issues

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/FluentDataGrid.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/DataGrid/FluentDataGrid.md
@@ -45,6 +45,8 @@ again will toggle the sort direction. When `HeaderCellAsButtonWithMenu` is true,
 A sort can be removed by right clicking (or by pressing <kbd>Shift</kbd> + <kbd>r</kbd>) on the header column (with exception of
 the default sort).
 
+_The minimal width for a sortable column is 75 pixels._
+
 ## Row size
 
 The DataGrid offers a `RowSize` parameter which allows you to use different preset row heights. The value uses the `DataGridRowSize`

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor
@@ -118,8 +118,6 @@
 
                 @if (Sortable.HasValue ? Sortable.Value : IsSortableByDefault())
                 {
-
-                    // <FluentButton Appearance="ButtonAppearance.Subtle" Class="col-sort-button" Style="@($"width: calc(100% - {wdelta});")" @onclick="@(() => Grid.SortByColumnAsync(this))" aria-label="@tooltip" title="@tooltip" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
                     <FluentButton Appearance="ButtonAppearance.Subtle" Class="col-sort-button" @onclick="@(() => Grid.SortByColumnAsync(this))" aria-label="@tooltip" title="@tooltip" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
                         <div class="col-title-text" title="@tooltip">
                             @HeaderTitleContent

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor
@@ -145,7 +145,7 @@
                 }
                 else
                 {
-					<div class="col-title" style="width: 100%;">
+					<div class="col-title">
                         <div class="col-title-text" title="@tooltip">
                             @HeaderTitleContent
                             @if (ColumnOptions is not null && Filtered.GetValueOrDefault() && Grid.ResizeType.HasValue)

--- a/src/Core/Components/DataGrid/Columns/ColumnBase.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnBase.razor
@@ -120,7 +120,7 @@
                 {
 
                     // <FluentButton Appearance="ButtonAppearance.Subtle" Class="col-sort-button" Style="@($"width: calc(100% - {wdelta});")" @onclick="@(() => Grid.SortByColumnAsync(this))" aria-label="@tooltip" title="@tooltip" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
-                    <FluentButton Appearance="ButtonAppearance.Subtle" Class="col-sort-button" Style="width: 100%;" @onclick="@(() => Grid.SortByColumnAsync(this))" aria-label="@tooltip" title="@tooltip" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
+                    <FluentButton Appearance="ButtonAppearance.Subtle" Class="col-sort-button" @onclick="@(() => Grid.SortByColumnAsync(this))" aria-label="@tooltip" title="@tooltip" @oncontextmenu="@(() => Grid.RemoveSortByColumnAsync(this))">
                         <div class="col-title-text" title="@tooltip">
                             @HeaderTitleContent
                         </div>

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -1023,6 +1023,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         .AddStyle("border-collapse", "separate", GenerateHeader == DataGridGeneratedHeaderType.Sticky)
         .AddStyle("border-spacing", "0", GenerateHeader == DataGridGeneratedHeaderType.Sticky)
         .AddStyle("width", "100%", DisplayMode == DataGridDisplayMode.Table)
+        .AddStyle("table-layout", "fixed", DisplayMode == DataGridDisplayMode.Table)
         .Build();
 
     private string? GridClass => DefaultClassBuilder

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.css
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.css
@@ -57,7 +57,7 @@
 }
 
 .fluent-data-grid .col-sort-button {
-  width: calc(100% - 20px);
+  width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 75px;

--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.css
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.css
@@ -60,6 +60,7 @@
   width: calc(100% - 20px);
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 75px;
 }
 
 .fluent-data-grid .col-sort-button {
@@ -69,19 +70,23 @@
 .fluent-data-grid .col-justify-start .col-sort-button {
   justify-content: start;
   overflow: hidden;
-  opacity: 1
+  opacity: 1;
+  min-width: 75px;
 }
 
 .fluent-data-grid .col-justify-center .col-sort-button {
   justify-content: center;
   overflow: hidden;
-  opacity: 1
+  opacity: 1;
+  min-width: 75px;
 }
 
 .fluent-data-grid .col-justify-end .col-sort-button  {
   justify-content: end;
   overflow: hidden;
-  opacity: 1
+  opacity: 1;
+  min-width: 75px;
+
 }
 
 

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_ColumnOptionsUISettings.verified.razor.html
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_ColumnOptionsUISettings.verified.razor.html
@@ -6,7 +6,7 @@
 				<tr class="fluent-data-grid-row" data-row-index="0" role="row" row-type="header" blazor:onkeydown="x" blazor:onclick="x" blazor:ondblclick="5" blazor:onfocus="6">
 					<th col-index="1" class="column-header col-justify-start col-sort-asc" style="grid-column: 1; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="25" scope="col" aria-sort="ascending">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Name</div>
 							</div>
 						</div>

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_ColumnResizeUISettings.verified.razor.html
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_ColumnResizeUISettings.verified.razor.html
@@ -6,7 +6,7 @@
 				<tr class="fluent-data-grid-row" data-row-index="0" role="row" row-type="header" blazor:onkeydown="x" blazor:onclick="x" blazor:ondblclick="5" blazor:onfocus="6">
 					<th col-index="1" class="column-header col-justify-start col-sort-asc" style="grid-column: 1; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="25" scope="col" aria-sort="ascending">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Name</div>
 							</div>
 						</div>

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_ColumnSortUISettings.verified.razor.html
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_ColumnSortUISettings.verified.razor.html
@@ -6,7 +6,7 @@
 				<tr class="fluent-data-grid-row" data-row-index="0" role="row" row-type="header" blazor:onkeydown="x" blazor:onclick="x" blazor:ondblclick="5" blazor:onfocus="6">
 					<th col-index="1" class="column-header col-justify-start col-sort-asc" style="grid-column: 1; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="25" scope="col" aria-sort="ascending">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Name</div>
 							</div>
 						</div>

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_Default.verified.razor.html
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_Default.verified.razor.html
@@ -6,7 +6,7 @@
 				<tr class="fluent-data-grid-row" data-row-index="0" role="row" row-type="header" blazor:onkeydown="x" blazor:onclick="x" blazor:ondblclick="5" blazor:onfocus="6">
 					<th col-index="1" class="column-header col-justify-start col-sort-asc" style="grid-column: 1; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="25" scope="col" aria-sort="ascending">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Name</div>
 							</div>
 						</div>

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_IsFixed.verified.razor.html
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_IsFixed.verified.razor.html
@@ -6,7 +6,7 @@
 				<tr class="fluent-data-grid-row" data-row-index="0" role="row" row-type="header" blazor:onkeydown="x" blazor:onclick="x" blazor:ondblclick="5" blazor:onfocus="6">
 					<th col-index="1" class="column-header col-justify-start col-sort-asc" style="min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="16" scope="col" aria-sort="ascending">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Name</div>
 							</div>
 						</div>

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_StickyHeader.verified.razor.html
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_StickyHeader.verified.razor.html
@@ -6,7 +6,7 @@
 				<tr class="fluent-data-grid-row" data-row-index="0" role="row" row-type="sticky-header" blazor:onkeydown="x" blazor:onclick="x" blazor:ondblclick="5" blazor:onfocus="6">
 					<th col-index="1" class="column-header col-justify-start col-sort-asc" style="grid-column: 1; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="25" scope="col" aria-sort="ascending">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Name</div>
 							</div>
 						</div>

--- a/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_StripedRows.verified.razor.html
+++ b/tests/Core/Components/DataGrid/FluentDataGridTests.FluentDataGrid_StripedRows.verified.razor.html
@@ -6,7 +6,7 @@
 				<tr class="fluent-data-grid-row" data-row-index="0" role="row" row-type="header" blazor:onkeydown="x" blazor:onclick="x" blazor:ondblclick="5" blazor:onfocus="6">
 					<th col-index="1" class="column-header col-justify-start col-sort-asc" style="grid-column: 1; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="25" scope="col" aria-sort="ascending">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Name</div>
 							</div>
 						</div>

--- a/tests/Core/Components/DataGrid/HierarchicalSelectColumnTests.HierarchicalSelectColumnTests_Rendering.verified.razor.html
+++ b/tests/Core/Components/DataGrid/HierarchicalSelectColumnTests.HierarchicalSelectColumnTests_Rendering.verified.razor.html
@@ -6,7 +6,7 @@
 				<tr class="fluent-data-grid-row" data-row-index="0" role="row" row-type="header" blazor:onkeydown="x" blazor:onclick="x" blazor:ondblclick="5" blazor:onfocus="6">
 					<th col-index="1" class="column-header col-justify-start" style="grid-column: 1; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="21" scope="col" aria-sort="none">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Id</div>
 							</div>
 						</div>

--- a/tests/Core/Components/DataGrid/SelectColumnTests.SelectColumnTests_MultiSelect_Customized_Rendering.verified.razor.html
+++ b/tests/Core/Components/DataGrid/SelectColumnTests.SelectColumnTests_MultiSelect_Customized_Rendering.verified.razor.html
@@ -9,7 +9,7 @@
 					</th>
 					<th col-index="2" class="column-header col-justify-start" style="grid-column: 2; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="30" scope="col" aria-sort="none">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Name</div>
 							</div>
 						</div>

--- a/tests/Core/Components/DataGrid/SelectColumnTests.SelectColumnTests_MultiSelect_Rendering.verified.razor.html
+++ b/tests/Core/Components/DataGrid/SelectColumnTests.SelectColumnTests_MultiSelect_Rendering.verified.razor.html
@@ -13,7 +13,7 @@
 					</th>
 					<th col-index="2" class="column-header col-justify-start" style="grid-column: 2; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="28" scope="col" aria-sort="none">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Name</div>
 							</div>
 						</div>

--- a/tests/Core/Components/DataGrid/SelectColumnTests.SelectColumnTests_SingleSelect_Rendering.verified.razor.html
+++ b/tests/Core/Components/DataGrid/SelectColumnTests.SelectColumnTests_SingleSelect_Rendering.verified.razor.html
@@ -7,7 +7,7 @@
 					<th col-index="1" class="column-header select-all col-justify-center col-select" style="grid-column: 1; text-align: center; align-content: center; padding-top: 10px; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="25" scope="col" aria-sort="none"></th>
 					<th col-index="2" class="column-header col-justify-start" style="grid-column: 2; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="28" scope="col" aria-sort="none">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Name</div>
 							</div>
 						</div>

--- a/tests/Core/Components/DataGrid/SelectColumnTests.SelectColumnTests_SingleStickySelect_Rendering.verified.razor.html
+++ b/tests/Core/Components/DataGrid/SelectColumnTests.SelectColumnTests_SingleStickySelect_Rendering.verified.razor.html
@@ -7,7 +7,7 @@
 					<th col-index="1" class="column-header select-all col-justify-center col-select" style="grid-column: 1; text-align: center; align-content: center; padding-top: 10px; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="25" scope="col" aria-sort="none"></th>
 					<th col-index="2" class="column-header col-justify-start" style="grid-column: 2; height: 32px; min-height: 40px; z-index: 5;" blazor:oncontextmenu:preventdefault="" blazor:onkeydown="x" blazor:onclick="x" blazor:onfocus="28" scope="col" aria-sort="none">
 						<div style="display: flex; justify-content: flex-start; padding: 0 6px; ">
-							<div class="col-title" style="width: 100%;">
+							<div class="col-title">
 								<div class="col-title-text">Name</div>
 							</div>
 						</div>


### PR DESCRIPTION
Fixes issues mentioned in #4582 

1. Header not applying width twice
Yup, the style=100% is the culprit here. I'll remove it and verify.

2. Additional space when sortable is enabled
The optimal min-width is arbitrary and depends mostly on what title you are using. With the word year and applying a sort (so the arrow gets shown (with its own margin/padding)) the minimal with could be brought down to around 80 pixels. I'll set the min-width to 75px in the CSS.
There was also a calc that subtracted 20px from the width. I'll remove that also

3. Wrong sizing
When switching to table layout, the table uses the default table-layout: auto, the column width is being determined by the content of the entire column (not just the ). The browser will expand the column to fit it's content. I'll change it so that it uses table-layout: fixed in that mode. It already sets it to that when resizing is enabled anyway