### PR TITLE
[dev-v5][Calendar] Put current year in middle row in year view

### DIFF
--- a/src/Core/Components/DateTime/CalendarExtended.cs
+++ b/src/Core/Components/DateTime/CalendarExtended.cs
@@ -12,6 +12,12 @@ namespace Microsoft.FluentUI.AspNetCore.Components.Calendar;
 /// </summary>
 internal struct CalendarExtended
 {
+
+    /// <summary>
+    /// Gets the number of year to add to the current year to center the current year in the list of years in the "Years" view.
+    /// </summary>
+    internal const int YearShiftCentered = 5; // Used in GetYearsRange()
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CalendarExtended"/> class.
     /// </summary>
@@ -100,7 +106,12 @@ internal struct CalendarExtended
     {
         var maxCount = 12;
         var maxYear = Culture.Calendar.MaxSupportedDateTime.GetYear(Culture);
-        var year = Date.GetYear(Culture);
+        var year = Date.GetYear(Culture) - YearShiftCentered;
+
+        if (year < Culture.Calendar.MinSupportedDateTime.GetYear(Culture))
+        {
+            year = Culture.Calendar.MinSupportedDateTime.GetYear(Culture);
+        }
 
         if (year + maxCount > maxYear)
         {

--- a/src/Core/Components/DateTime/CalendarTitles.cs
+++ b/src/Core/Components/DateTime/CalendarTitles.cs
@@ -90,7 +90,7 @@ internal class CalendarTitles<TValue>
             {
                 CalendarViews.Days => CalendarExtended.GetMonthName(Date.AddMonths(-1, _calendar.Culture)),
                 CalendarViews.Months => CalendarExtended.GetYear(Date.AddYears(-1, _calendar.Culture)),
-                CalendarViews.Years => CalendarExtended.GetYearsRangeLabel(Date.GetYear(_calendar.Culture) - 12),
+                CalendarViews.Years => CalendarExtended.GetYearsRangeLabel(Date.GetYear(_calendar.Culture) - 12 - CalendarExtended.YearShiftCentered),
                 _ => string.Empty
             };
         }
@@ -111,7 +111,7 @@ internal class CalendarTitles<TValue>
             {
                 CalendarViews.Days => Date.Year == minDate.Year && Date.Month == minDate.Month,
                 CalendarViews.Months => Date.Year == minDate.Year,
-                CalendarViews.Years => Date.Year == minDate.Year,
+                CalendarViews.Years => Date.Year - CalendarExtended.YearShiftCentered <= minDate.Year,
                 _ => false
             };
         }
@@ -128,7 +128,7 @@ internal class CalendarTitles<TValue>
             {
                 CalendarViews.Days => CalendarExtended.GetMonthName(Date.AddMonths(+1, _calendar.Culture)),
                 CalendarViews.Months => CalendarExtended.GetYear(Date.AddYears(+1, _calendar.Culture)),
-                CalendarViews.Years => CalendarExtended.GetYearsRangeLabel(Date.GetYear(_calendar.Culture) + 12),
+                CalendarViews.Years => CalendarExtended.GetYearsRangeLabel(Date.GetYear(_calendar.Culture) + 12 - CalendarExtended.YearShiftCentered),
                 _ => string.Empty
             };
         }
@@ -147,7 +147,7 @@ internal class CalendarTitles<TValue>
             {
                 CalendarViews.Days => Date.Year == maxDate.Year && Date.Month == maxDate.Month,
                 CalendarViews.Months => Date.Year == maxDate.Year,
-                CalendarViews.Years => Date.Year == maxDate.Year,
+                CalendarViews.Years => Date.Year + 12 - CalendarExtended.YearShiftCentered >= maxDate.Year,
                 _ => false
             };
         }

--- a/src/Core/Components/DateTime/CalendarTitles.cs
+++ b/src/Core/Components/DateTime/CalendarTitles.cs
@@ -72,7 +72,7 @@ internal class CalendarTitles<TValue>
 #pragma warning disable MA0011
                 CalendarViews.Days => CalendarExtended.GetMonthNameAndYear(),
                 CalendarViews.Months => CalendarExtended.GetYear(),
-                CalendarViews.Years => CalendarExtended.GetYearsRangeLabel(Date.GetYear(_calendar.Culture)),
+                CalendarViews.Years => CalendarExtended.GetYearsRangeLabel(Date.GetYear(_calendar.Culture) - CalendarExtended.YearShiftCentered),
 #pragma warning restore MA0011
                 _ => string.Empty
             };
@@ -111,7 +111,7 @@ internal class CalendarTitles<TValue>
             {
                 CalendarViews.Days => Date.Year == minDate.Year && Date.Month == minDate.Month,
                 CalendarViews.Months => Date.Year == minDate.Year,
-                CalendarViews.Years => Date.Year - CalendarExtended.YearShiftCentered <= minDate.Year,
+                CalendarViews.Years => Date.Year - CalendarExtended.YearShiftCentered <= minDate.Year + 12,
                 _ => false
             };
         }

--- a/src/Core/Extensions/DateTimeExtensions.cs
+++ b/src/Core/Extensions/DateTimeExtensions.cs
@@ -366,6 +366,11 @@ public static class DateTimeExtensions
     /// <returns></returns>
     public static DateTime AddYears(this DateTime value, int years, CultureInfo culture)
     {
+        if (culture.Calendar.MaxSupportedDateTime.Year - value.Year < years)
+        {
+            return culture.Calendar.MaxSupportedDateTime;
+        }
+
         return culture.Calendar.AddYears(value, years);
     }
 

--- a/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_Maximum_View-years.verified.razor.html
+++ b/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_Maximum_View-years.verified.razor.html
@@ -1,27 +1,27 @@
 
 <fluent-field id="xxx" label-position="above">
-			<div id="xxx" class="fluent-calendar fluent-year-view" slot="input" blazor:onfocusout="1" blazor:elementreference="xxx">
-				<input type="datetime" value="9999-12-31" hidden="">
-				<div>
-					<div class="title" part="title" aria-label="9999">
-						<div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">9999</div>
-						<div part="move" class="change-period">
-							<div class="previous" title="9982 - 9993" blazor:onclick="x" role="button" tabindex="0">
-								<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-									<path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
-								</svg>
-							</div>
-							<div class="next" disabled=""></div>
-						</div>
+	<div id="xxx" class="fluent-calendar fluent-year-view" slot="input" blazor:onfocusout="1" blazor:elementreference="xxx">
+		<input type="datetime" value="9999-12-31" hidden="">
+		<div>
+			<div class="title" part="title" aria-label="9994 - 9999">
+				<div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">9994 - 9999</div>
+				<div part="move" class="change-period">
+					<div class="previous" title="9982 - 9993" blazor:onclick="x" role="button" tabindex="0">
+						<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+							<path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
+						</svg>
 					</div>
-					<div class="years" part="years">
-						<div class="year" aria-label="9994" title="9994" value="9994" tabindex="0" blazor:onclick="x">9994</div>
-						<div class="year" aria-label="9995" title="9995" value="9995" tabindex="0" blazor:onclick="x">9995</div>
-						<div class="year" aria-label="9996" title="9996" value="9996" tabindex="0" blazor:onclick="x">9996</div>
-						<div class="year" aria-label="9997" title="9997" value="9997" tabindex="0" blazor:onclick="x">9997</div>
-						<div class="year" aria-label="9998" title="9998" value="9998" tabindex="0" blazor:onclick="x">9998</div>
-						<div class="year" selected="" aria-label="9999" title="9999" value="9999" tabindex="0" blazor:onclick="x">9999</div>
-					</div>
+					<div class="next" disabled=""></div>
 				</div>
 			</div>
-		</fluent-field>
+			<div class="years" part="years">
+				<div class="year" aria-label="9994" title="9994" value="9994" tabindex="0" blazor:onclick="x">9994</div>
+				<div class="year" aria-label="9995" title="9995" value="9995" tabindex="0" blazor:onclick="x">9995</div>
+				<div class="year" aria-label="9996" title="9996" value="9996" tabindex="0" blazor:onclick="x">9996</div>
+				<div class="year" aria-label="9997" title="9997" value="9997" tabindex="0" blazor:onclick="x">9997</div>
+				<div class="year" aria-label="9998" title="9998" value="9998" tabindex="0" blazor:onclick="x">9998</div>
+				<div class="year" selected="" aria-label="9999" title="9999" value="9999" tabindex="0" blazor:onclick="x">9999</div>
+			</div>
+		</div>
+	</div>
+</fluent-field>

--- a/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_Maximum_View-years.verified.razor.html
+++ b/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_Maximum_View-years.verified.razor.html
@@ -1,22 +1,27 @@
 
 <fluent-field id="xxx" label-position="above">
-  <div id="xxx" class="fluent-calendar fluent-year-view" slot="input" blazor:onfocusout="1" blazor:elementreference="xxx">
-    <input type="datetime" value="9999-12-31" hidden="">
-    <div>
-      <div class="title" part="title" aria-label="9999">
-        <div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">9999</div>
-        <div part="move" class="change-period">
-          <div class="previous" title="9987 - 9998" blazor:onclick="x" role="button" tabindex="0">
-            <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
-            </svg>
-          </div>
-          <div class="next" disabled=""></div>
-        </div>
-      </div>
-      <div class="years" part="years">
-        <div class="year" selected="" aria-label="9999" title="9999" value="9999" tabindex="0" blazor:onclick="x">9999</div>
-      </div>
-    </div>
-  </div>
-</fluent-field>
+			<div id="xxx" class="fluent-calendar fluent-year-view" slot="input" blazor:onfocusout="1" blazor:elementreference="xxx">
+				<input type="datetime" value="9999-12-31" hidden="">
+				<div>
+					<div class="title" part="title" aria-label="9999">
+						<div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">9999</div>
+						<div part="move" class="change-period">
+							<div class="previous" title="9982 - 9993" blazor:onclick="x" role="button" tabindex="0">
+								<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+									<path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
+								</svg>
+							</div>
+							<div class="next" disabled=""></div>
+						</div>
+					</div>
+					<div class="years" part="years">
+						<div class="year" aria-label="9994" title="9994" value="9994" tabindex="0" blazor:onclick="x">9994</div>
+						<div class="year" aria-label="9995" title="9995" value="9995" tabindex="0" blazor:onclick="x">9995</div>
+						<div class="year" aria-label="9996" title="9996" value="9996" tabindex="0" blazor:onclick="x">9996</div>
+						<div class="year" aria-label="9997" title="9997" value="9997" tabindex="0" blazor:onclick="x">9997</div>
+						<div class="year" aria-label="9998" title="9998" value="9998" tabindex="0" blazor:onclick="x">9998</div>
+						<div class="year" selected="" aria-label="9999" title="9999" value="9999" tabindex="0" blazor:onclick="x">9999</div>
+					</div>
+				</div>
+			</div>
+		</fluent-field>

--- a/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_Minimum_View-years.verified.razor.html
+++ b/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_Minimum_View-years.verified.razor.html
@@ -7,7 +7,7 @@
                 <div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">1 - 12</div>
                 <div part="move" class="change-period">
                     <div class="previous" disabled=""></div>
-                    <div class="next" title="13 - 24" blazor:onclick="x" role="button" tabindex="0">
+                    <div class="next" title="8 - 19" blazor:onclick="x" role="button" tabindex="0">
                         <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                             <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
                         </svg>

--- a/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_TitleClick-months.verified.razor.html
+++ b/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_TitleClick-months.verified.razor.html
@@ -1,40 +1,39 @@
-
 <fluent-field id="xxx" label-position="above">
-  <div id="xxx" class="fluent-calendar fluent-month-view" slot="input" blazor:onfocusout="1" blazor:elementreference="xxx">
-    <input type="datetime" value="2022-04-15" hidden="">
-    <div id="xxx" class="fluent-calendar fluent-year-view" slot="input" blazor:onfocusout="17" blazor:elementreference="xxx">
-      <input type="datetime" value="2022-04-01" hidden="">
-      <div>
-        <div class="title" part="title" aria-label="2022 - 2033">
-          <div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">2022 - 2033</div>
-          <div part="move" class="change-period">
-            <div class="previous" title="2010 - 2021" blazor:onclick="x" role="button" tabindex="0">
-              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
-              </svg>
-            </div>
-            <div class="next" title="2034 - 2045" blazor:onclick="x" role="button" tabindex="0">
-              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
-              </svg>
+    <div id="xxx" class="fluent-calendar fluent-month-view" slot="input" blazor:onfocusout="1" blazor:elementreference="xxx">
+      <input type="datetime" value="2022-04-15" hidden="">
+      <div id="xxx" class="fluent-calendar fluent-year-view" slot="input" blazor:onfocusout="17" blazor:elementreference="xxx">
+        <input type="datetime" value="2022-04-01" hidden="">
+        <div>
+          <div class="title" part="title" aria-label="2022 - 2033">
+            <div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">2022 - 2033</div>
+            <div part="move" class="change-period">
+              <div class="previous" title="2005 - 2016" blazor:onclick="x" role="button" tabindex="0">
+                <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
+                </svg>
+              </div>
+              <div class="next" title="2029 - 2040" blazor:onclick="x" role="button" tabindex="0">
+                <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
+                </svg>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="years" part="years">
-          <div class="year" selected="" aria-label="2022" title="2022" value="2022" tabindex="0" blazor:onclick="x">2022</div>
-          <div class="year" aria-label="2023" title="2023" value="2023" tabindex="0" blazor:onclick="x">2023</div>
-          <div class="year" aria-label="2024" title="2024" value="2024" tabindex="0" blazor:onclick="x">2024</div>
-          <div class="year" aria-label="2025" title="2025" value="2025" tabindex="0" blazor:onclick="x">2025</div>
-          <div class="year" aria-label="2026" title="2026" value="2026" tabindex="0" blazor:onclick="x">2026</div>
-          <div class="year" aria-label="2027" title="2027" value="2027" tabindex="0" blazor:onclick="x">2027</div>
-          <div class="year" aria-label="2028" title="2028" value="2028" tabindex="0" blazor:onclick="x">2028</div>
-          <div class="year" aria-label="2029" title="2029" value="2029" tabindex="0" blazor:onclick="x">2029</div>
-          <div class="year" aria-label="2030" title="2030" value="2030" tabindex="0" blazor:onclick="x">2030</div>
-          <div class="year" aria-label="2031" title="2031" value="2031" tabindex="0" blazor:onclick="x">2031</div>
-          <div class="year" aria-label="2032" title="2032" value="2032" tabindex="0" blazor:onclick="x">2032</div>
-          <div class="year" aria-label="2033" title="2033" value="2033" tabindex="0" blazor:onclick="x">2033</div>
+          <div class="years" part="years">
+            <div class="year" aria-label="2017" title="2017" value="2017" tabindex="0" blazor:onclick="x">2017</div>
+            <div class="year" aria-label="2018" title="2018" value="2018" tabindex="0" blazor:onclick="x">2018</div>
+            <div class="year" aria-label="2019" title="2019" value="2019" tabindex="0" blazor:onclick="x">2019</div>
+            <div class="year" aria-label="2020" title="2020" value="2020" tabindex="0" blazor:onclick="x">2020</div>
+            <div class="year" aria-label="2021" title="2021" value="2021" tabindex="0" blazor:onclick="x">2021</div>
+            <div class="year" selected="" aria-label="2022" title="2022" value="2022" tabindex="0" blazor:onclick="x">2022</div>
+            <div class="year" aria-label="2023" title="2023" value="2023" tabindex="0" blazor:onclick="x">2023</div>
+            <div class="year" aria-label="2024" title="2024" value="2024" tabindex="0" blazor:onclick="x">2024</div>
+            <div class="year" aria-label="2025" title="2025" value="2025" tabindex="0" blazor:onclick="x">2025</div>
+            <div class="year" aria-label="2026" title="2026" value="2026" tabindex="0" blazor:onclick="x">2026</div>
+            <div class="year" aria-label="2027" title="2027" value="2027" tabindex="0" blazor:onclick="x">2027</div>
+            <div class="year" aria-label="2028" title="2028" value="2028" tabindex="0" blazor:onclick="x">2028</div>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</fluent-field>
+  </fluent-field>

--- a/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_TitleClick-months.verified.razor.html
+++ b/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_TitleClick-months.verified.razor.html
@@ -4,8 +4,8 @@
       <div id="xxx" class="fluent-calendar fluent-year-view" slot="input" blazor:onfocusout="17" blazor:elementreference="xxx">
         <input type="datetime" value="2022-04-01" hidden="">
         <div>
-          <div class="title" part="title" aria-label="2022 - 2033">
-            <div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">2022 - 2033</div>
+          <div class="title" part="title" aria-label="2017 - 2028">
+            <div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">2017 - 2028</div>
             <div part="move" class="change-period">
               <div class="previous" title="2005 - 2016" blazor:onclick="x" role="button" tabindex="0">
                 <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_TitleClick-years.verified.razor.html
+++ b/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_TitleClick-years.verified.razor.html
@@ -2,8 +2,8 @@
     <div id="xxx" class="fluent-calendar fluent-year-view" slot="input" blazor:onfocusout="1" blazor:elementreference="xxx">
       <input type="datetime" value="2022-04-15" hidden="">
       <div>
-        <div class="title" part="title" aria-label="2022 - 2033">
-          <div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">2022 - 2033</div>
+        <div class="title" part="title" aria-label="2017 - 2028">
+          <div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">2017 - 2028</div>
           <div part="move" class="change-period">
             <div class="previous" title="2005 - 2016" blazor:onclick="x" role="button" tabindex="0">
               <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_TitleClick-years.verified.razor.html
+++ b/tests/Core/Components/DateTimes/FluentCalendarTests.FluentCalendar_TitleClick-years.verified.razor.html
@@ -1,37 +1,36 @@
-
 <fluent-field id="xxx" label-position="above">
-  <div id="xxx" class="fluent-calendar fluent-year-view" slot="input" blazor:onfocusout="1" blazor:elementreference="xxx">
-    <input type="datetime" value="2022-04-15" hidden="">
-    <div>
-      <div class="title" part="title" aria-label="2022 - 2033">
-        <div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">2022 - 2033</div>
-        <div part="move" class="change-period">
-          <div class="previous" title="2010 - 2021" blazor:onclick="x" role="button" tabindex="0">
-            <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
-            </svg>
-          </div>
-          <div class="next" title="2034 - 2045" blazor:onclick="x" role="button" tabindex="0">
-            <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
-            </svg>
+    <div id="xxx" class="fluent-calendar fluent-year-view" slot="input" blazor:onfocusout="1" blazor:elementreference="xxx">
+      <input type="datetime" value="2022-04-15" hidden="">
+      <div>
+        <div class="title" part="title" aria-label="2022 - 2033">
+          <div part="label" class="label" role="button" tabindex="0" blazor:onclick="x">2022 - 2033</div>
+          <div part="move" class="change-period">
+            <div class="previous" title="2005 - 2016" blazor:onclick="x" role="button" tabindex="0">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M4.2 10.73a.75.75 0 001.1 1.04l5.95-6.25v14.73a.75.75 0 001.5 0V5.52l5.95 6.25a.75.75 0 001.1-1.04l-7.08-7.42a1 1 0 00-1.44 0L4.2 10.73z"></path>
+              </svg>
+            </div>
+            <div class="next" title="2029 - 2040" blazor:onclick="x" role="button" tabindex="0">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M19.8 13.27a.75.75 0 00-1.1-1.04l-5.95 6.25V3.75a.75.75 0 10-1.5 0v14.73L5.3 12.23a.75.75 0 10-1.1 1.04l7.08 7.42a1 1 0 001.44 0l7.07-7.42z"></path>
+              </svg>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="years" part="years">
-        <div class="year" selected="" aria-label="2022" title="2022" value="2022" tabindex="0" blazor:onclick="x">2022</div>
-        <div class="year" aria-label="2023" title="2023" value="2023" tabindex="0" blazor:onclick="x">2023</div>
-        <div class="year" aria-label="2024" title="2024" value="2024" tabindex="0" blazor:onclick="x">2024</div>
-        <div class="year" aria-label="2025" title="2025" value="2025" tabindex="0" blazor:onclick="x">2025</div>
-        <div class="year" aria-label="2026" title="2026" value="2026" tabindex="0" blazor:onclick="x">2026</div>
-        <div class="year" aria-label="2027" title="2027" value="2027" tabindex="0" blazor:onclick="x">2027</div>
-        <div class="year" aria-label="2028" title="2028" value="2028" tabindex="0" blazor:onclick="x">2028</div>
-        <div class="year" aria-label="2029" title="2029" value="2029" tabindex="0" blazor:onclick="x">2029</div>
-        <div class="year" aria-label="2030" title="2030" value="2030" tabindex="0" blazor:onclick="x">2030</div>
-        <div class="year" aria-label="2031" title="2031" value="2031" tabindex="0" blazor:onclick="x">2031</div>
-        <div class="year" aria-label="2032" title="2032" value="2032" tabindex="0" blazor:onclick="x">2032</div>
-        <div class="year" aria-label="2033" title="2033" value="2033" tabindex="0" blazor:onclick="x">2033</div>
+        <div class="years" part="years">
+          <div class="year" aria-label="2017" title="2017" value="2017" tabindex="0" blazor:onclick="x">2017</div>
+          <div class="year" aria-label="2018" title="2018" value="2018" tabindex="0" blazor:onclick="x">2018</div>
+          <div class="year" aria-label="2019" title="2019" value="2019" tabindex="0" blazor:onclick="x">2019</div>
+          <div class="year" aria-label="2020" title="2020" value="2020" tabindex="0" blazor:onclick="x">2020</div>
+          <div class="year" aria-label="2021" title="2021" value="2021" tabindex="0" blazor:onclick="x">2021</div>
+          <div class="year" selected="" aria-label="2022" title="2022" value="2022" tabindex="0" blazor:onclick="x">2022</div>
+          <div class="year" aria-label="2023" title="2023" value="2023" tabindex="0" blazor:onclick="x">2023</div>
+          <div class="year" aria-label="2024" title="2024" value="2024" tabindex="0" blazor:onclick="x">2024</div>
+          <div class="year" aria-label="2025" title="2025" value="2025" tabindex="0" blazor:onclick="x">2025</div>
+          <div class="year" aria-label="2026" title="2026" value="2026" tabindex="0" blazor:onclick="x">2026</div>
+          <div class="year" aria-label="2027" title="2027" value="2027" tabindex="0" blazor:onclick="x">2027</div>
+          <div class="year" aria-label="2028" title="2028" value="2028" tabindex="0" blazor:onclick="x">2028</div>
+        </div>
       </div>
     </div>
-  </div>
-</fluent-field>
+  </fluent-field>

--- a/tests/Core/Components/DateTimes/FluentCalendarTests.razor
+++ b/tests/Core/Components/DateTimes/FluentCalendarTests.razor
@@ -442,7 +442,7 @@ value=""2022-02-20"">20</div>");
     [Theory]
     [InlineData(CalendarViews.Days, "May 2022")]
     [InlineData(CalendarViews.Months, "2023")]
-    [InlineData(CalendarViews.Years, "2034 - 2045")]
+    [InlineData(CalendarViews.Years, "2029 - 2040")]
     public void FluentCalendar_NextButton(CalendarViews view, string nextTitle)
     {
         using var context = new DateTimeProviderContext(DateTime.Now);
@@ -466,7 +466,7 @@ value=""2022-02-20"">20</div>");
     [Theory]
     [InlineData(CalendarViews.Days, "March 2022")]
     [InlineData(CalendarViews.Months, "2021")]
-    [InlineData(CalendarViews.Years, "2010 - 2021")]
+    [InlineData(CalendarViews.Years, "2005 - 2016")]
     public void FluentCalendar_PreviousButton(CalendarViews view, string nextTitle)
     {
         using var context = new DateTimeProviderContext(DateTime.Now);

--- a/tests/Core/Components/DateTimes/Utilities/CalendarExtendedTests.cs
+++ b/tests/Core/Components/DateTimes/Utilities/CalendarExtendedTests.cs
@@ -102,8 +102,8 @@ public class CalendarExtendedTests
 
         // Assert
         Assert.Equal(12, years.Count);
-        Assert.Equal(2020, years.First().Year);
-        Assert.Equal(2031, years.Last().Year);
+        Assert.Equal(2015, years.First().Year);
+        Assert.Equal(2026, years.Last().Year);
     }
 
     [Fact]

--- a/tests/Core/Components/DateTimes/Utilities/CalendarTitlesTests.razor
+++ b/tests/Core/Components/DateTimes/Utilities/CalendarTitlesTests.razor
@@ -84,7 +84,7 @@
     [Theory]
     [InlineData(CalendarViews.Days, "June")]
     [InlineData(CalendarViews.Months, "2023")]
-    [InlineData(CalendarViews.Years, "2012 - 2023")]
+    [InlineData(CalendarViews.Years, "2007 - 2018")]
     [InlineData((CalendarViews)99, "")] // Default case
     public void CalendarTitles_PreviousTitle_ReturnsCorrectValue(CalendarViews view, string expected)
     {
@@ -131,7 +131,7 @@
     [Theory]
     [InlineData(CalendarViews.Days, "August")]
     [InlineData(CalendarViews.Months, "2025")]
-    [InlineData(CalendarViews.Years, "2036 - 2047")]
+    [InlineData(CalendarViews.Years, "2031 - 2042")]
     [InlineData((CalendarViews)99, "")] // Default case
     public void CalendarTitles_NextTitle_ReturnsCorrectValue(CalendarViews view, string expected)
     {

--- a/tests/Core/Components/DateTimes/Utilities/CalendarTitlesTests.razor
+++ b/tests/Core/Components/DateTimes/Utilities/CalendarTitlesTests.razor
@@ -61,7 +61,7 @@
     [Theory]
     [InlineData(CalendarViews.Days, "July 2024")]
     [InlineData(CalendarViews.Months, "2024")]
-    [InlineData(CalendarViews.Years, "2024 - 2035")]
+    [InlineData(CalendarViews.Years, "2019 - 2030")]
     [InlineData((CalendarViews)99, "")] // Default case
     public void CalendarTitles_Label_ReturnsCorrectValue(CalendarViews view, string expected)
     {


### PR DESCRIPTION
# [dev-v5] Center current year in calendar view

Adjust the calendar view to center the current year and improve the AddYears method to handle maximum date constraints.
Fixes unit tests to reflect these changes.

Before
<img width="322" height="340" alt="{A813B835-0431-4BA5-9E1B-A321BF29D242}" src="https://github.com/user-attachments/assets/b8213a1c-7cf0-4428-9be4-97b5036332b0" />

After
<img width="324" height="340" alt="{3D72719B-F01E-4965-A391-8A7ECFC129B6}" src="https://github.com/user-attachments/assets/92334198-85d5-498e-806d-fd4a5354c20b" />

See #4591

## Unit Tests

Updated