### PR TITLE
[dev-v5] Fix accordion change event to trigger only for fluent-accordion

### DIFF
--- a/src/Core.Scripts/src/FluentUICustomEvents.ts
+++ b/src/Core.Scripts/src/FluentUICustomEvents.ts
@@ -14,6 +14,12 @@ export namespace Microsoft.FluentUI.Blazor.FluentUICustomEvents {
     blazor.registerCustomEventType('accordionchange', {
       browserEventName: 'change',
       createEventArgs: event => {
+
+        const isAccordion = event.target instanceof Element && event.target.tagName.toLowerCase() === 'fluent-accordion';
+        if (!isAccordion) {
+          return null;
+        }
+
         const item: any = event.target.accordionItems[event.target.activeItemIndex];
         const header = item?.querySelector(`[slot="heading"]`)?.innerText ?? null;
         return {


### PR DESCRIPTION
# [dev-v5] Fix accordion change event to trigger only for fluent-accordion

Fix #4595

When a **FluentSelect** is used inside a **FluentAccordionItem**, the following error occurs when a new value is selected (even without a value binding): 
```
Uncaught TypeError: can't access property "undefined", m.target.accordionItems is undefined createEventArgs.
```

## Unit Tests

Unchanged