### PR TITLE
Add Fluent UI to button, select, input and textarea

### DIFF
--- a/src/Core/wwwroot/css/reboot.css
+++ b/src/Core/wwwroot/css/reboot.css
@@ -32,18 +32,19 @@ body, .body {
     color: var(--neutral-foreground-rest);
     background-color: var(--neutral-fill-layer-rest);
     -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
-body[data-theme="light"],
-body[data-theme="system-light"] {
-    color-scheme: light;
-}
+    body[data-theme="light"],
+    body[data-theme="system-light"] {
+        color-scheme: light;
+    }
 
-body[data-theme="dark"],
-body[data-theme="system-dark"] {
-    color-scheme: dark;
-}
+    body[data-theme="dark"],
+    body[data-theme="system-dark"] {
+        color-scheme: dark;
+    }
 
 hr {
     margin: 1rem 0;
@@ -90,7 +91,6 @@ h6 {
     line-height: var(--type-ramp-base-line-height);
 }
 
-
 p {
     font-size: var(--type-ramp-base-font-size);
     line-height: var(--type-ramp-base-line-height);
@@ -98,11 +98,6 @@ p {
     margin-top: 0;
     margin-bottom: 1rem;
     font-family: var(--body-font);
-}
-
-
-a {
-
 }
 
 blockquote {
@@ -159,6 +154,7 @@ dd {
     margin-bottom: 0.5rem;
     margin-left: 0;
 }
+
 /*
 blockquote {
     margin: 0 0 1rem;
@@ -207,7 +203,8 @@ a {
         color: var(--accent-foreground-active);
     }
 
-    a:not([href]):not([class]), a:not([href]):not([class]):hover {
+    a:not([href]):not([class]),
+    a:not([href]):not([class]):hover {
         color: inherit;
         text-decoration: none;
     }
@@ -286,6 +283,7 @@ caption {
 th {
     text-align: inherit;
     text-align: -webkit-match-parent;
+    text-align: match-parent;
 }
 
 thead,
@@ -303,13 +301,9 @@ label {
     display: inline-block;
 }
 
-button {
-    border-radius: var(--control-corner-radius);
+button:focus:not(:focus-visible) {
+    outline: 0;
 }
-
-    button:focus:not(:focus-visible) {
-        outline: 0;
-    }
 
 input,
 button,
@@ -322,7 +316,6 @@ textarea {
     line-height: inherit;
     border: 1px solid black;
 }
-
 
 button,
 select {
@@ -350,6 +343,7 @@ button,
 [type=reset],
 [type=submit] {
     -webkit-appearance: button;
+    appearance: button;
 }
 
     button:not(:disabled),
@@ -411,6 +405,7 @@ legend + * {
 [type=search] {
     outline-offset: -2px;
     -webkit-appearance: textfield;
+    appearance: textfield;
 }
 
 /* rtl:raw:
@@ -419,8 +414,8 @@ legend + * {
 [type="email"],
 [type="number"] {
   direction: ltr;
-}
-*/
+}*/
+
 ::-webkit-search-decoration {
     -webkit-appearance: none;
 }
@@ -437,6 +432,80 @@ legend + * {
 ::file-selector-button {
     font: inherit;
     -webkit-appearance: button;
+    appearance: button;
+}
+
+input:not([type=button]):not([type=reset]):not([type=submit]):not([type=file]):not([type=range]):not([type=checkbox]):not([type=radio]),
+textarea {
+    background: padding-box linear-gradient(var(--neutral-fill-input-rest), var(--neutral-fill-input-rest)), border-box var(--neutral-stroke-input-rest);
+    border: calc(var(--stroke-width) * 1px) solid transparent;
+    border-radius: calc(var(--control-corner-radius) * 1px);
+    color: var(--neutral-foreground-rest);
+    fill: currentcolor;
+    outline: 0;
+}
+
+@media (forced-colors: none) {
+
+    input:not([type=button]):not([type=reset]):not([type=submit]):not([type=file]):not([type=range]):not([type=checkbox]):not([type=radio]):not(:disabled):active,
+    input:not([type=button]):not([type=reset]):not([type=submit]):not([type=file]):not([type=range]):not([type=checkbox]):not([type=radio]):not(:disabled):focus-within,
+    textarea:not(:disabled):active,
+    textarea:not(:disabled):focus-within {
+        border-bottom: calc(var(--stroke-width) * 1px) solid var(--accent-fill-rest);
+    }
+}
+
+button,
+select,
+input[type=button],
+input[type=reset],
+input[type=submit],
+::-webkit-file-upload-button,
+::file-selector-button {
+    border: calc(var(--stroke-width) * 1px) solid transparent;
+    background: padding-box linear-gradient(var(--neutral-fill-rest), var(--neutral-fill-rest)), border-box var(--neutral-stroke-control-rest);
+    color: var(--neutral-foreground-rest);
+    border-radius: calc(var(--control-corner-radius) * 1px);
+    fill: currentcolor;
+}
+
+    button:not(:disabled):active,
+    select:not(:disabled):active,
+    input[type=button]:not(:disabled):active,
+    input[type=reset]:not(:disabled):active,
+    input[type=submit]:not(:disabled):active,
+    :not(:disabled):active::-webkit-file-upload-button,
+    :not(:disabled):active::file-selector-button {
+        background: padding-box linear-gradient(var(--neutral-fill-active), var(--neutral-fill-active)), border-box var(--neutral-stroke-control-active);
+    }
+
+    button:not(:disabled):hover,
+    select:not(:disabled):hover,
+    input[type=button]:not(:disabled):hover,
+    input[type=reset]:not(:disabled):hover,
+    input[type=submit]:not(:disabled):hover,
+    :not(:disabled):hover::-webkit-file-upload-button,
+    :not(:disabled):hover::file-selector-button {
+        background: padding-box linear-gradient(var(--neutral-fill-hover), var(--neutral-fill-hover)), border-box var(--neutral-stroke-control-hover);
+    }
+
+    button:disabled,
+    select:disabled,
+    input[type=button]:disabled,
+    input[type=reset]:disabled,
+    input[type=submit]:disabled,
+    :disabled::-webkit-file-upload-button,
+    :disabled::file-selector-button {
+        background: padding-box linear-gradient(var(--neutral-fill-rest), var(--neutral-fill-rest)), border-box var(--neutral-stroke-rest);
+        opacity: var(--disabled-opacity);
+        cursor: not-allowed;
+    }
+
+option,
+optgroup {
+    background: var(--neutral-fill-stealth-rest);
+    color: var(--neutral-foreground-rest);
+    fill: currentcolor;
 }
 
 output {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

Add Fluent UI to button, select, input and textarea. I don't know why it does not have apply Fluent UI to the native controls, so I add it. If no fluent ui on native controls is a feature, please ignore this PR.

Before:
![Light](https://github.com/user-attachments/assets/d71d1c56-dca3-457a-ad77-e17812f331c1)
![Dark](https://github.com/user-attachments/assets/ee537c62-ad65-4528-aafe-bba0afed7e25)

After:
![Light](https://github.com/user-attachments/assets/3b6d6811-cb3c-4236-9f72-b2a473cc5677)
![Dark](https://github.com/user-attachments/assets/3ee0b11e-bc70-43e6-8833-29ca3b751035)

## 👩‍💻 Reviewer Notes

I only test it on Edge 145.0.3800.97 in Windows. I'm not sure it works fine in other platforms. A simple test is here: [test.zip](https://github.com/user-attachments/files/25866466/test.zip)

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [ ] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component
