### PR TITLE
[dev-v5] Update theme generator for numeric CSS variables

### DIFF
--- a/src/Core.Scripts/_ExtractCssVariables.ps1
+++ b/src/Core.Scripts/_ExtractCssVariables.ps1
@@ -15,6 +15,14 @@ function Get-CssVariableLines {
         [bool]$IsConstants = $true
     )
 
+    # List of CSS variables defined as numbers
+    $numberVariables = @(
+        "fontWeightRegular",
+        "fontWeightMedium",
+        "fontWeightSemibold",
+        "fontWeightBold"
+    )
+
     # Read the content of the file
     $fileContent = Get-Content -Path ".\node_modules\@fluentui\web-components\dist\web-components.d.ts"
 
@@ -139,8 +147,16 @@ function Get-CssVariableLines {
                         $lines.Add("        public const string $(Fix-SizeName("$prefix$g2$($entry.Groupe3)")) = ""$($entry.Groupe4)"";")
                     }
                     else {
+
+                        if ($numberVariables -contains "$(Fix-JsonAttribute($entry.Groupe4))") {
+                            $dataType = "int?"
+                        }
+                        else {
+                            $dataType = "string?"
+                        }
+
                         $lines.Add("        [JsonPropertyName(""$(Fix-JsonAttribute($entry.Groupe4))"")]")
-                        $lines.Add("        public string? $(Fix-SizeName("$prefix$g2$($entry.Groupe3)")) { get; set; }")
+                        $lines.Add("        public $dataType $(Fix-SizeName("$prefix$g2$($entry.Groupe3)")) { get; set; }")
                         
                         $dico.Add([System.Collections.Generic.KeyValuePair[string, string]]::new($(Fix-JsonAttribute($entry.Groupe4)), "$g1.$(Fix-SizeName("$prefix$g2$($entry.Groupe3)"))"))
                     }
@@ -178,8 +194,16 @@ function Get-CssVariableLines {
                         $lines.Add("            public const string $(Fix-SizeName($entry.Groupe3)) = ""$($entry.Groupe4)"";")
                     }
                     else {
+
+                        if ($numberVariables -contains "$(Fix-JsonAttribute($entry.Groupe4))") {
+                            $dataType = "int?"
+                        }
+                        else {
+                            $dataType = "string?"
+                        }
+
                         $lines.Add("            [JsonPropertyName(""$(Fix-JsonAttribute($entry.Groupe4))"")]")
-                        $lines.Add("            public string? $(Fix-SizeName($entry.Groupe3)) { get; set; }")
+                        $lines.Add("            public $dataType $(Fix-SizeName($entry.Groupe3)) { get; set; }")
                   
                         $dico.Add([System.Collections.Generic.KeyValuePair[string, string]]::new($(Fix-JsonAttribute($entry.Groupe4)), "$g1.$g2.$(Fix-SizeName($entry.Groupe3))"))
                     }
@@ -193,9 +217,9 @@ function Get-CssVariableLines {
 
     if (!$IsConstants) {
         $lines.Add("    /// <summary />")
-        $lines.Add("    public IDictionary<string, string?> ToDictionary()")
+        $lines.Add("    public IDictionary<string, object?> ToDictionary()")
         $lines.Add("    {")
-        $lines.Add("        return new Dictionary<string, string?>")
+        $lines.Add("        return new Dictionary<string, object?>")
         $lines.Add("        {")
         foreach ($item in $dico) {
             $key = $item.Key
@@ -206,13 +230,19 @@ function Get-CssVariableLines {
         $lines.Add("    }")
         $lines.Add("")
         $lines.Add("    /// <summary />")
-        $lines.Add("    public void FromDictionary(IDictionary<string, string?> value)")
+        $lines.Add("    public void FromDictionary(IDictionary<string, object?> value)")
         $lines.Add("    {")
-        $lines.Add("        string? GetValue(string key) => value.TryGetValue(key, out var result) ? result : null;")
+        $lines.Add("       string? GetValue(string key) => value.TryGetValue(key, out var result) ? result?.ToString() : null;")
+        $lines.Add("       int? GetIntValue(string key) => value.TryGetValue(key, out var result) && int.TryParse(result?.ToString(), out var intValue) ? intValue : null;")
         foreach ($item in $dico) {
             $key = $item.Key
             $value = $item.Value
-            $lines.Add("        $value = GetValue(""$key"");")
+            if ($numberVariables -contains "$key") {
+                $lines.Add("        $value = GetIntValue(""$key"");")
+            }
+            else {                
+                $lines.Add("        $value = GetValue(""$key"");")
+            }
         }
         $lines.Add("    }")
     }

--- a/src/Core/Components/Theme/Styles/Theme.cs
+++ b/src/Core/Components/Theme/Styles/Theme.cs
@@ -1808,19 +1808,19 @@ public partial class Theme
         {
             /// <summary />
             [JsonPropertyName("fontWeightBold")]
-            public string? Bold { get; set; }
+            public int? Bold { get; set; }
 
             /// <summary />
             [JsonPropertyName("fontWeightMedium")]
-            public string? Medium { get; set; }
+            public int? Medium { get; set; }
 
             /// <summary />
             [JsonPropertyName("fontWeightRegular")]
-            public string? Regular { get; set; }
+            public int? Regular { get; set; }
 
             /// <summary />
             [JsonPropertyName("fontWeightSemibold")]
-            public string? Semibold { get; set; }
+            public int? Semibold { get; set; }
 
         }
     }
@@ -2073,9 +2073,9 @@ public partial class Theme
         }
     }
     /// <summary />
-    public IDictionary<string, string?> ToDictionary()
+    public IDictionary<string, object?> ToDictionary()
     {
-        return new Dictionary<string, string?>
+        return new Dictionary<string, object?>
         {
             ["borderRadius2XLarge"] = Borders.Radius.Large2X,
             ["borderRadius3XLarge"] = Borders.Radius.Large3X,
@@ -2540,9 +2540,10 @@ public partial class Theme
     }
 
     /// <summary />
-    public void FromDictionary(IDictionary<string, string?> value)
+    public void FromDictionary(IDictionary<string, object?> value)
     {
-        string? GetValue(string key) => value.TryGetValue(key, out var result) ? result : null;
+       string? GetValue(string key) => value.TryGetValue(key, out var result) ? result?.ToString() : null;
+       int? GetIntValue(string key) => value.TryGetValue(key, out var result) && int.TryParse(result?.ToString(), out var intValue) ? intValue : null;
         Borders.Radius.Large2X = GetValue("borderRadius2XLarge");
         Borders.Radius.Large3X = GetValue("borderRadius3XLarge");
         Borders.Radius.Large4X = GetValue("borderRadius4XLarge");
@@ -2950,10 +2951,10 @@ public partial class Theme
         Fonts.Size.Hero700 = GetValue("fontSizeHero700");
         Fonts.Size.Hero800 = GetValue("fontSizeHero800");
         Fonts.Size.Hero900 = GetValue("fontSizeHero900");
-        Fonts.Weight.Bold = GetValue("fontWeightBold");
-        Fonts.Weight.Medium = GetValue("fontWeightMedium");
-        Fonts.Weight.Regular = GetValue("fontWeightRegular");
-        Fonts.Weight.Semibold = GetValue("fontWeightSemibold");
+        Fonts.Weight.Bold = GetIntValue("fontWeightBold");
+        Fonts.Weight.Medium = GetIntValue("fontWeightMedium");
+        Fonts.Weight.Regular = GetIntValue("fontWeightRegular");
+        Fonts.Weight.Semibold = GetIntValue("fontWeightSemibold");
         Lines.Height.Base100 = GetValue("lineHeightBase100");
         Lines.Height.Base200 = GetValue("lineHeightBase200");
         Lines.Height.Base300 = GetValue("lineHeightBase300");

--- a/src/Core/Components/Theme/Styles/ThemeExtensions.cs
+++ b/src/Core/Components/Theme/Styles/ThemeExtensions.cs
@@ -10,13 +10,43 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 public static class ThemeExtensions
 {
     /// <summary>
+    /// Converts the current theme custom object to a dictionary, excluding properties with null, empty string, or zero values.
+    /// </summary>
+    /// <param name="theme"></param>
+    /// <returns></returns>
+    public static IDictionary<string, object?> ToCompactDictionary(this Theme theme)
+    {
+        return theme.ToDictionary().Where(i => !IsEmptyValue(i.Value)).ToDictionary();
+
+        static bool IsEmptyValue(object? value)
+        {
+            if (value is null)
+            {
+                return true;
+            }
+
+            if (value is string strValue)
+            {
+                return string.IsNullOrEmpty(strValue);
+            }
+
+            if (value is int intValue)
+            {
+                return intValue == 0;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Converts the current theme custom object to a JSON string.
     /// </summary>
     /// <returns></returns>
     [RequiresUnreferencedCode("This method uses reflection which may be trimmed.")]
     public static string ToJson(this Theme theme)
     {
-        var dico = theme.ToDictionary().Where(i => !string.IsNullOrEmpty(i.Value));
+        var dico = theme.ToCompactDictionary();
         var data = System.Linq.Enumerable.ToDictionary(dico, x => x.Key, x => x.Value, StringComparer.Ordinal);
         var options = new System.Text.Json.JsonSerializerOptions
         {
@@ -34,7 +64,7 @@ public static class ThemeExtensions
     [RequiresUnreferencedCode("This method uses reflection which may be trimmed.")]
     public static Theme FromJson(this Theme Theme, string json)
     {
-        var data = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string?>>(json);
+        var data = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object?>>(json);
         if (data is not null)
         {
             Theme.FromDictionary(data);

--- a/tests/Core/Components/Themes/ThemeTests.cs
+++ b/tests/Core/Components/Themes/ThemeTests.cs
@@ -17,50 +17,54 @@ public partial class ThemeTests
         // Act
         theme.Borders.Radius.Medium = "0px";
         theme.Borders.Radius.Small = "2px";
+        theme.Fonts.Weight.Bold = 700;
 
         // Assert
         var jsonResult = theme.ToJson();
-        Assert.Equal(2, jsonResult.Split(",").Length);
+        Assert.Equal(3, jsonResult.Split(",").Length);
         Assert.Contains("\"borderRadiusMedium\": \"0px\"", jsonResult);
         Assert.Contains("\"borderRadiusSmall\": \"2px\"", jsonResult);
+        Assert.Contains("\"fontWeightBold\": 700", jsonResult);
     }
 
     [Fact]
     public void Theme_Deserialization()
     {
         // Arrange
-        var json = "{ \"borderRadiusLarge\": \"4px\", \"borderRadius2XLarge\": \"8px\" }";
+        var json = "{ \"borderRadiusLarge\": \"4px\", \"borderRadius2XLarge\": \"8px\", \"fontWeightBold\": 700 }";
         var theme = new Theme(json);
 
         // Act
-        var dictionary = theme.ToDictionary()
-                              .Where(i => !string.IsNullOrEmpty(i.Value))
-                              .ToDictionary();
+        var dictionary = theme.ToCompactDictionary();
 
         // Assert
-        Assert.Equal(2, dictionary.Count());
+        Assert.Equal(3, dictionary.Count());
         Assert.Equal("4px", dictionary["borderRadiusLarge"]);
         Assert.Equal("8px", dictionary["borderRadius2XLarge"]);
+        Assert.Equal(700, dictionary["fontWeightBold"]);
     }
 
     [Fact]
     public void Theme_Combine()
     {
         // Arrange
-        var json = "{ \"borderRadiusLarge\": \"4px\", \"borderRadius2XLarge\": \"8px\" }";
+        var json = "{ \"borderRadiusLarge\": \"4px\", \"borderRadius2XLarge\": \"8px\", \"fontWeightBold\": 700 }";
         var theme = new Theme();
         theme.FromJson(json);
 
         // Act
         theme.Borders.Radius.Medium = "3px";
         theme.Borders.Radius.Small = "2px";
+        theme.Fonts.Weight.Medium = 600;
 
         // Assert
         var jsonResult = theme.ToJson();
-        Assert.Equal(4, jsonResult.Split(",").Length);
+        Assert.Equal(6, jsonResult.Split(",").Length);
         Assert.Contains("\"borderRadiusLarge\": \"4px\"", jsonResult);
         Assert.Contains("\"borderRadius2XLarge\": \"8px\"", jsonResult);
         Assert.Contains("\"borderRadiusMedium\": \"3px\"", jsonResult);
         Assert.Contains("\"borderRadiusSmall\": \"2px\"", jsonResult);
+        Assert.Contains("\"fontWeightBold\": 700", jsonResult);
+        Assert.Contains("\"fontWeightMedium\": 600", jsonResult);
     }
 }


### PR DESCRIPTION
# [dev-v5] Update theme generator for numeric CSS variables

Enhance the theme generator to support numeric CSS variables and improve serialization. This change allows font weight properties to be treated as integers, ensuring better handling of numeric values in the theme. Additionally, introduce a method to convert the theme to a compact dictionary, filtering out empty values.

Example:
```csharp
public partial class ThemeFontsWeight
{
    [JsonPropertyName("fontWeightBold")]
    public string? Bold { get; set; }

    [JsonPropertyName("fontWeightMedium")]
    public string? Medium { get; set; }

    [JsonPropertyName("fontWeightRegular")]
    public string? Regular { get; set; }

    [JsonPropertyName("fontWeightSemibold")]
    public string? Semibold { get; set; }
}
```

```json
{
  "fontWeightBold": 700,
  "fontWeightMedium": 600,
  "fontWeightRegular": 500,
  "fontWeightSemibold": 400
}
```