### PR TITLE
Fix placeholder rendering error

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -65,7 +65,7 @@
 										OverscanCount="@OverscanCount"
 										ItemsProvider="@ProvideVirtualizedItemsAsync"
 										ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
-										Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))"
+										Placeholder="@(placeholderContext => builder => @RenderPlaceholderRow(builder, placeholderContext))"
 										SpacerElement="tr" />
 						}
 					}
@@ -147,21 +147,15 @@
 		string? _rowsDataSize = $"height: {ItemSize}px";
 
 		<FluentDataGridRow aria-rowindex="@(placeholderContext.Index + 1)" Style="@_rowsDataSize" TGridItem="TGridItem">
-			RenderPlaceholderCells(placeholderContext)
+            @for (var i = 0; i < _columns.Count; i++)
+            {
+                var col = _columns[i];
+
+                <FluentDataGridCell Class="@("grid-cell-placeholder " + @ColumnJustifyClass(col))" Style="@col.Style" @key="@col" GridColumn=@col.Index TGridItem="TGridItem">
+                    @((RenderFragment)(__builder => col.RenderPlaceholderContent(__builder, placeholderContext)))
+                </FluentDataGridCell>
+            }
 		</FluentDataGridRow>
-	}
-
-	[ExcludeFromCodeCoverage(Justification = "Circumvent EFCC shortcomings when using razor.")]
-	private void RenderPlaceholderCells(RenderTreeBuilder __builder, PlaceholderContext placeholderContext)
-	{
-		for (var i = 0; i < _columns.Count; i++)
-		{
-			var col = _columns[i];
-
-			<FluentDataGridCell Class="@("grid-cell-placeholder " + @ColumnJustifyClass(col))" Style="@col.Style" @key="@col" GridColumn=@col.Index TGridItem="TGridItem">
-				@((RenderFragment)(__builder => col.RenderPlaceholderContent(__builder, placeholderContext)))
-			</FluentDataGridCell>
-		}
 	}
 
 	private void RenderColumnHeaders(RenderTreeBuilder __builder)

--- a/src/Core/Components/DataGrid/FluentDataGrid.razor
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor
@@ -65,7 +65,7 @@
 										OverscanCount="@OverscanCount"
 										ItemsProvider="@ProvideVirtualizedItemsAsync"
 										ItemContent="@(item => builder => RenderRow(builder, item.RowIndex, item.Data))"
-										Placeholder="@(placeholderContext => builder => @RenderPlaceholderRow(builder, placeholderContext))"
+										Placeholder="@(placeholderContext => builder => RenderPlaceholderRow(builder, placeholderContext))"
 										SpacerElement="tr" />
 						}
 					}


### PR DESCRIPTION
Fix #4608 be moving the rendering of the placeholder cells back into rendering the placeholder row. No idea why this change was made. It was always one method before