### PR TITLE
[dev-v5][Calendar] Fix getting stuck in month or year selection

### DIFF
--- a/src/Core/Components/DateTime/CalendarTValue.cs
+++ b/src/Core/Components/DateTime/CalendarTValue.cs
@@ -66,7 +66,7 @@ internal static class CalendarTValue
             DateOnly d => d.ToDateTime(),
             DateTimeOffset dto => dto.DateTime,
             TimeOnly t => t.ToDateTime(),
-            _ => null
+            _ => null,
         };
     }
 
@@ -96,7 +96,7 @@ internal static class CalendarTValue
             Type t when t == typeof(DateOnly?) => (TValue)(object)(DateOnly?)DateOnly.FromDateTime(value),
             Type t when t == typeof(TimeOnly) => (TValue)(object)TimeOnly.FromDateTime(value),
             Type t when t == typeof(TimeOnly?) => (TValue)(object)(TimeOnly?)TimeOnly.FromDateTime(value),
-            _ => throw new ArgumentException($"Unsupported type: {typeof(TValue)}", nameof(value))
+            _ => throw new ArgumentException($"Unsupported type: {typeof(TValue)}", nameof(value)),
         };
     }
 

--- a/src/Core/Components/DateTime/FluentCalendar.razor.cs
+++ b/src/Core/Components/DateTime/FluentCalendar.razor.cs
@@ -292,15 +292,13 @@ public partial class FluentCalendar<TValue> : FluentCalendarBase<TValue>
         {
             var value = Culture.Calendar.ToDateTime(year, month, 1, 0, 0, 0, 0);
 
-
             if (value == CurrentValue?.ConvertToDateTime())
             {
                 // Even if the month is the same as the current value, we need to update the day to the first day of the month, and trigger the event.
                 // Otherwise, the user cannot return to the day view.
-                await ValueChanged.InvokeAsync(CurrentValue);
+                await ValueChanged.InvokeAsync(value.ConvertToTValue<TValue>());
                 return;
             }
-
 
             await OnSelectedDateHandlerAsync(value);
         }
@@ -317,7 +315,7 @@ public partial class FluentCalendar<TValue> : FluentCalendarBase<TValue>
             {
                 // Even if the year is the same as the current value, we need to update the month and day to the first month and day of the year, and trigger the event.
                 // Otherwise, the user cannot return to the month view.
-                await ValueChanged.InvokeAsync(CurrentValue);
+                await ValueChanged.InvokeAsync(value.ConvertToTValue<TValue>());
                 return;
             }
 

--- a/src/Core/Components/DateTime/FluentCalendar.razor.cs
+++ b/src/Core/Components/DateTime/FluentCalendar.razor.cs
@@ -291,6 +291,17 @@ public partial class FluentCalendar<TValue> : FluentCalendarBase<TValue>
         if (!isReadOnly)
         {
             var value = Culture.Calendar.ToDateTime(year, month, 1, 0, 0, 0, 0);
+
+
+            if (value == CurrentValue?.ConvertToDateTime())
+            {
+                // Even if the month is the same as the current value, we need to update the day to the first day of the month, and trigger the event.
+                // Otherwise, the user cannot return to the day view.
+                await ValueChanged.InvokeAsync(CurrentValue);
+                return;
+            }
+
+
             await OnSelectedDateHandlerAsync(value);
         }
     }
@@ -301,6 +312,15 @@ public partial class FluentCalendar<TValue> : FluentCalendarBase<TValue>
         if (!isReadOnly)
         {
             var value = Culture.Calendar.ToDateTime(year, 1, 1, 0, 0, 0, 0);
+
+            if (value == CurrentValue?.ConvertToDateTime())
+            {
+                // Even if the year is the same as the current value, we need to update the month and day to the first month and day of the year, and trigger the event.
+                // Otherwise, the user cannot return to the month view.
+                await ValueChanged.InvokeAsync(CurrentValue);
+                return;
+            }
+
             await OnSelectedDateHandlerAsync(value);
         }
     }

--- a/src/Core/Components/DateTime/RangeOfDates.cs
+++ b/src/Core/Components/DateTime/RangeOfDates.cs
@@ -26,9 +26,7 @@ internal class RangeOfDates : RangeOf<System.DateTime>
     {
         return GetRangeValues((min, max) =>
         {
-            return Enumerable.Range(0, (max - min).Days + 1)
-                             .Select(offset => min.AddDays(offset))
-                             .ToArray();
+            return [.. Enumerable.Range(0, (max - min).Days + 1).Select(offset => min.AddDays(offset))];
         });
     }
 

--- a/tests/Core/Components/DateTimes/FluentCalendarTests.razor
+++ b/tests/Core/Components/DateTimes/FluentCalendarTests.razor
@@ -528,7 +528,7 @@ value=""2022-02-20"">20</div>");
         april!.Click();
 
         // Assert
-        Assert.Equal("2022", calendar.Find(".label").TextContent);
+        Assert.Equal("April 2022", calendar.Find(".label").TextContent);
     }
 
     [Fact]


### PR DESCRIPTION
Navigate to https://fluentui-blazor-v5.azurewebsites.net/DateTime/Calendar. In the default example click on the calendar title (march 2026 at this time). Now click on march again. You cannot get back to the day view. Same goes for year (although you need to click on year, month, year again to get stuck). 

This is currently not a big issue yet because you can click on another month or year and go back again, but when using MinDate/MaxDate (introduced in a different PR) and the choice is limited to one month or year, a user will **not** be able to get back to the day view.

Also fixes some compiler warnings.