### PR TITLE
[dev-v5][DataGrid] Fix SelectedItems getting unselected when using pagination (and virtualization)

### DIFF
--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -25,6 +25,9 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>, IDisposable
 
     private IEnumerable<TGridItem> _selectedItems = [];
 
+    private Func<TGridItem, object>? _lastItemKey;
+    private IEqualityComparer<TGridItem>? _itemKeyComparer;
+
     /// <summary />
     protected readonly Icon IconUnselectedMultiple = new CoreIcons.Regular.Size20.CheckboxUnchecked();
     /// <summary />
@@ -239,6 +242,33 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>, IDisposable
     [Parameter]
     public IEqualityComparer<TGridItem>? Comparer { get; set; } = null;
 
+    private IEqualityComparer<TGridItem>? EffectiveComparer
+    {
+        get
+        {
+            if (Comparer is not null)
+            {
+                return Comparer;
+            }
+
+            // When paging/virtualizing, items can be re-materialized (new instances). In that case,
+            // we want selection to be based on the grid's stable key (ItemKey) by default.
+            var itemKey = InternalGridContext?.Grid?.ItemKey;
+            if (itemKey is null)
+            {
+                return null;
+            }
+
+            if (_itemKeyComparer is null || !ReferenceEquals(_lastItemKey, itemKey))
+            {
+                _lastItemKey = itemKey;
+                _itemKeyComparer = new ItemKeyEqualityComparer(itemKey);
+            }
+
+            return _itemKeyComparer;
+        }
+    }
+
     /// <summary>
     /// Allows to clear the selection.
     /// </summary>
@@ -344,17 +374,18 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>, IDisposable
     {
         if (item != null && (Selectable == null || Selectable.Invoke(item)))
         {
+            var comparer = EffectiveComparer;
             var selectedItems = SelectedItems.ToList();
-            if (selectedItems.Contains(item, Comparer))
+            if (selectedItems.Contains(item, comparer))
             {
                 if (SelectMode is DataGridSelectMode.SingleSticky)
                 {
                     return;
                 }
 
-                if (Comparer != null)
+                if (comparer != null)
                 {
-                    var toRemove = selectedItems.First(i => Comparer.Equals(i, item));
+                    var toRemove = selectedItems.First(i => comparer.Equals(i, item));
                     selectedItems.Remove(toRemove);
                 }
                 else
@@ -407,7 +438,15 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>, IDisposable
             return;
         }
 
-        var itemsToRemove = SelectedItems.Where(item => !InternalGridContext.Items.Contains(item, Comparer)).ToList();
+        // When the grid only has a subset of the full data set in memory (pagination and/or virtualization),
+        // the current Items collection does not represent all rows. In that case we must not remove selected
+        // items just because they are not in the current slice.
+        if (InternalGridContext.TotalItemCount > 0 && InternalGridContext.Items.Count < InternalGridContext.TotalItemCount)
+        {
+            return;
+        }
+
+        var itemsToRemove = SelectedItems.Where(item => !InternalGridContext.Items.Contains(item, EffectiveComparer)).ToList();
         foreach (var item in itemsToRemove)
         {
             await AddOrRemoveSelectedItemAsync(item);
@@ -476,7 +515,8 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>, IDisposable
                 return;
             }
 
-            var contained = SelectedItems.Contains(item, Comparer);
+            var comparer = EffectiveComparer;
+            var contained = SelectedItems.Contains(item, comparer);
             var selected = contained || Property.Invoke(item);
 
             // Sync with SelectedItems list
@@ -489,7 +529,16 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>, IDisposable
             else if (!selected && contained)
             {
                 var selectedItems = SelectedItems.ToList();
-                selectedItems.Remove(item);
+                if (comparer != null)
+                {
+                    var toRemove = selectedItems.First(i => comparer.Equals(i, item));
+                    selectedItems.Remove(toRemove);
+                }
+                else
+                {
+                    selectedItems.Remove(item);
+                }
+
                 SelectedItems = selectedItems;
             }
 
@@ -671,6 +720,34 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>, IDisposable
     public void Dispose()
     {
         _itemsChanged.Dispose();
+    }
+
+    private sealed class ItemKeyEqualityComparer(Func<TGridItem, object> itemKey) : IEqualityComparer<TGridItem>
+    {
+        private readonly Func<TGridItem, object> _itemKey = itemKey;
+
+        public bool Equals(TGridItem? x, TGridItem? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            var xKey = _itemKey(x);
+            var yKey = _itemKey(y);
+            return EqualityComparer<object?>.Default.Equals(xKey, yKey);
+        }
+
+        public int GetHashCode(TGridItem obj)
+        {
+            var key = _itemKey(obj);
+            return EqualityComparer<object?>.Default.GetHashCode(key);
+        }
     }
 }
 

--- a/src/Core/Components/DataGrid/Columns/SelectColumn.cs
+++ b/src/Core/Components/DataGrid/Columns/SelectColumn.cs
@@ -238,7 +238,10 @@ public class SelectColumn<TGridItem> : ColumnBase<TGridItem>, IDisposable
     /// </summary>
     /// <remarks>If not set, the default equality comparer for <typeparamref name="TGridItem"/> is used.
     /// Setting this property allows customization of how grid items are compared for equality, which can affect
-    /// operations such as selection, filtering, or updating items in the grid.</remarks>
+    /// operations such as selection, filtering, or updating items in the grid.
+    /// When <see cref="Comparer"/> is <see langword="null"/>, the grid uses an effective comparer: it may fall back
+    /// to a key-based comparer derived from <see cref="FluentDataGrid{TGridItem}.ItemKey"/> when available, which can
+    /// differ from <see cref="System.Collections.Generic.EqualityComparer{TGridItem}.Default"/> for <typeparamref name="TGridItem"/>.</remarks>
     [Parameter]
     public IEqualityComparer<TGridItem>? Comparer { get; set; } = null;
 

--- a/tests/Core/Components/DataGrid/SelectColumnTests.razor
+++ b/tests/Core/Components/DataGrid/SelectColumnTests.razor
@@ -12,6 +12,18 @@
         public bool Selected { get; set; }
     };
 
+    public sealed class PersonEntity
+    {
+        public PersonEntity(int personId, string name)
+        {
+            PersonId = personId;
+            Name = name;
+        }
+
+        public int PersonId { get; }
+        public string Name { get; }
+    }
+
     private readonly IQueryable<Person> People = new[]
     {
         new Person(1, "Jean Martin", new DateOnly(1985, 3, 16)),
@@ -1294,6 +1306,117 @@
         Assert.Empty(SelectedItems);
     }
 
+    [Fact]
+    public async Task FluentDataGrid_ColumSelect_MultiSelect_SelectedItems_PersistAcrossPagination()
+    {
+        var items = new[]
+        {
+        new Person(1, "A", new DateOnly(1985, 3, 16)),
+        new Person(2, "B", new DateOnly(2004, 1, 9)),
+        new Person(3, "C", new DateOnly(1958, 10, 10)),
+        new Person(4, "D", new DateOnly(1991, 12, 1)),
+    }.AsQueryable();
+
+        var pagination = new PaginationState { ItemsPerPage = 2 };
+        IEnumerable<Person> SelectedItems = Array.Empty<Person>();
+
+        var cut = Render(
+    @<div>
+        <FluentDataGrid Items="@items" Pagination="@pagination" TGridItem="Person">
+            <SelectColumn TGridItem="Person"
+                          SelectMode="@DataGridSelectMode.Multiple"
+                          @bind-SelectedItems="@SelectedItems" />
+            <PropertyColumn Property="@(p => p.Name)" />
+        </FluentDataGrid>
+        <FluentPaginator State="@pagination" />
+    </div>);
+
+    // Select an item on page 1
+        await ClickOnRowAsync(cut, row: 0);
+        Assert.Single(SelectedItems);
+        var firstSelectedId = SelectedItems.First().PersonId;
+
+        // Move to page 2
+        var grid = cut.FindComponent<FluentDataGrid<Person>>();
+        await grid.InvokeAsync(() => pagination.SetCurrentPageIndexAsync(1));
+        grid.Render();
+
+        // The selection must remain when paging
+        Assert.Single(SelectedItems);
+        Assert.Equal(firstSelectedId, SelectedItems.First().PersonId);
+
+        // Select another item on page 2
+        await ClickOnRowAsync(cut, row: 0);
+        Assert.Equal(2, SelectedItems.Count());
+    }
+
+    [Fact]
+    public async Task FluentDataGrid_ColumSelect_MultiSelect_SelectedItems_VisuallyRestoresAcrossPagination_WhenItemsAreRematerialized_AndItemKeyIsSet()
+    {
+        var all = new[]
+        {
+            (Id: 1, Name: "A"),
+            (Id: 2, Name: "B"),
+            (Id: 3, Name: "C"),
+            (Id: 4, Name: "D"),
+        };
+
+        var pagination = new PaginationState { ItemsPerPage = 2 };
+        IEnumerable<PersonEntity> selectedItems = Array.Empty<PersonEntity>();
+
+        GridItemsProvider<PersonEntity> provider = request =>
+        {
+            var count = request.Count ?? all.Length;
+            var items = all
+                .Skip(request.StartIndex)
+                .Take(count)
+                // Important: new instances each time to simulate re-materialization (e.g., EF).
+                .Select(p => new PersonEntity(p.Id, p.Name))
+                .ToList();
+
+            return ValueTask.FromResult(GridItemsProviderResult.From<PersonEntity>(items, all.Length));
+        };
+
+        var cut = Render(
+    @<div>
+        <FluentDataGrid ItemsProvider="@provider" Pagination="@pagination" ItemKey="@(p => p.PersonId)" TGridItem="PersonEntity">
+            <SelectColumn TGridItem="PersonEntity"
+                          SelectMode="@DataGridSelectMode.Multiple"
+                          @bind-SelectedItems="@selectedItems" />
+            <PropertyColumn Property="@(p => p.Name)" />
+        </FluentDataGrid>
+        <FluentPaginator State="@pagination" />
+    </div>);
+
+        // Select an item on page 1
+        await ClickOnRowAsync<PersonEntity>(cut, row: 0);
+        Assert.Single(selectedItems);
+        Assert.Single(cut.FindAll("svg[row-selected]"));
+
+        var selectedId = selectedItems.First().PersonId;
+
+        // Move to page 2
+        var grid = cut.FindComponent<FluentDataGrid<PersonEntity>>();
+        await grid.InvokeAsync(() => pagination.SetCurrentPageIndexAsync(1));
+        grid.Render();
+
+        // SelectedItems should persist, but the current page doesn't contain the selected row.
+        Assert.Single(selectedItems);
+        Assert.Equal(selectedId, selectedItems.First().PersonId);
+
+        // Move back to page 1
+        await grid.InvokeAsync(() => pagination.SetCurrentPageIndexAsync(0));
+        grid.Render();
+
+        // The row should be visually selected again even though items were re-materialized as new instances.
+        Assert.Single(cut.FindAll("svg[row-selected]"));
+
+        // And it should be possible to unselect it by clicking again (requires key-based removal, not reference-based).
+        await ClickOnRowAsync<PersonEntity>(cut, row: 0);
+        Assert.Empty(selectedItems);
+        Assert.Empty(cut.FindAll("svg[row-selected]"));
+    }
+
 #pragma warning restore BL0005
     /// <summary>
     /// Simulate a key down event on the DataGrid row number <paramref name="row"/>.
@@ -1312,6 +1435,24 @@
         };
         await item.Instance.HandleOnRowKeyDownAsync(item.Instance.RowId, keyboardEventArgs);
         cut.FindComponent<FluentDataGrid<Person>>().Render();
+    }
+
+    private async Task ClickOnRowAsync<TGridItem>(IRenderedComponent<ContainerFragment> cut, int row, int? col = null)
+    {
+        if (col == null)
+        {
+            var item = cut.FindComponents<FluentDataGridRow<TGridItem>>().ElementAt(row + 1);
+            await item.Instance.HandleOnRowClickAsync(item.Instance.RowId);
+            cut.FindComponent<FluentDataGrid<TGridItem>>().Render();
+        }
+        else
+        {
+            var item = cut.FindComponents<FluentDataGridCell<TGridItem>>()
+                          .Where(i => i.Instance.GridColumn == col + 1)
+                          .ElementAt(row + 1);
+            await item.Instance.HandleOnCellClickAsync();
+            cut.FindComponent<FluentDataGrid<TGridItem>>().Render();
+        }
     }
 
     /// <summary>

--- a/tests/Core/Components/DataGrid/SelectColumnTests.razor
+++ b/tests/Core/Components/DataGrid/SelectColumnTests.razor
@@ -78,13 +78,13 @@
         Assert.Empty(cut.FindAll("svg[row-selected]"));
         Assert.Empty(SelectedItems);
 
-        // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+     // Act - Click and select Row 0
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
     }
@@ -111,12 +111,12 @@
         Assert.Empty(SelectedItems);
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Empty(cut.FindAll("svg[row-selected]"));
         Assert.Empty(SelectedItems);
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
     }
@@ -142,12 +142,12 @@
         Assert.Empty(items.Where(i => i.Selected));
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(items.Where(i => i.Selected));
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(items.Where(i => i.Selected));
     }
@@ -175,12 +175,12 @@
         Assert.Empty(items.Where(i => i.Selected));
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Empty(cut.FindAll("svg[row-selected]"));
         Assert.Empty(items.Where(i => i.Selected));
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(items.Where(i => i.Selected));
     }
@@ -223,12 +223,12 @@
         Assert.Empty(SelectedItems);
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
     }
@@ -253,12 +253,12 @@
         Assert.Empty(SelectedItems);
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
 
         // Act - Click and select Row 0 a second time
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
     }
@@ -285,12 +285,12 @@
         Assert.Empty(SelectedItems);
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Empty(cut.FindAll("svg[row-selected]"));
         Assert.Empty(SelectedItems);
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
     }
@@ -316,12 +316,12 @@
         Assert.Empty(items.Where(i => i.Selected));
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(items.Where(i => i.Selected));
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(items.Where(i => i.Selected));
     }
@@ -349,12 +349,12 @@
         Assert.Empty(items.Where(i => i.Selected));
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Empty(cut.FindAll("svg[row-selected]"));
         Assert.Empty(items.Where(i => i.Selected));
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(items.Where(i => i.Selected));
     }
@@ -397,17 +397,17 @@
         Assert.Empty(SelectedItems);
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Equal(2, cut.FindAll("svg[row-selected]").Count);
         Assert.Equal(2, SelectedItems.Count());
 
         // Act - Click and unselect Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
     }
@@ -434,17 +434,17 @@
         Assert.Empty(SelectedItems);
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Empty(cut.FindAll("svg[row-selected]"));
         Assert.Empty(SelectedItems);
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
 
         // Act - Click and unselect Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Empty(cut.FindAll("svg[row-selected]"));
         Assert.Empty(SelectedItems);
     }
@@ -470,17 +470,17 @@
         Assert.Empty(items.Where(i => i.Selected));
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(items.Where(i => i.Selected));
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Equal(2, cut.FindAll("svg[row-selected]").Count);
         Assert.Equal(2, items.Where(i => i.Selected).Count());
 
         // Act - Click and unselect Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(items.Where(i => i.Selected));
     }
@@ -508,17 +508,17 @@
         Assert.Empty(items.Where(i => i.Selected));
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Empty(cut.FindAll("svg[row-selected]"));
         Assert.Empty(items.Where(i => i.Selected));
 
         // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(items.Where(i => i.Selected));
 
         // Act - Click and unselect Row 1
-        await ClickOnRowAsync(cut, row: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1);
         Assert.Empty(cut.FindAll("svg[row-selected]"));
         Assert.Empty(items.Where(i => i.Selected));
     }
@@ -684,16 +684,16 @@
         );
 
         // Act - Click on the second cell => no selection
-        await ClickOnRowAsync(cut, row: 0, col: 1);
+        await ClickOnRowAsync<Person>(cut, row: 0, col: 1);
         Assert.Empty(SelectedItems);
 
         // Act - Click on the first cell => select the row
-        await ClickOnRowAsync(cut, row: 0, col: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0, col: 0);
         Assert.Single(SelectedItems);
         Assert.Equal(1, SelectedItems.First().PersonId);
 
         // Act - Click on the second cell => keep the selection
-        await ClickOnRowAsync(cut, row: 1, col: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1, col: 1);
         Assert.Single(SelectedItems);
         Assert.Equal(1, SelectedItems.First().PersonId);
     }
@@ -715,21 +715,21 @@
             );
 
         // Act - Click on the second cell => no selection
-        await ClickOnRowAsync(cut, row: 0, col: 1);
+        await ClickOnRowAsync<Person>(cut, row: 0, col: 1);
         Assert.Empty(SelectedItems);
 
         // Act - Click on the first cell => select the row
-        await ClickOnRowAsync(cut, row: 0, col: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0, col: 0);
         Assert.Single(SelectedItems);
         Assert.Equal(1, SelectedItems.First().PersonId);
 
         // Act - Click on the second cell => keep the selection
-        await ClickOnRowAsync(cut, row: 1, col: 1);
+        await ClickOnRowAsync<Person>(cut, row: 1, col: 1);
         Assert.Single(SelectedItems);
         Assert.Equal(1, SelectedItems.First().PersonId);
 
         // Act - Click on the first cell => select another row
-        await ClickOnRowAsync(cut, row: 1, col: 0);
+        await ClickOnRowAsync<Person>(cut, row: 1, col: 0);
         Assert.Equal(2, SelectedItems.Count());
         Assert.Equal(1, SelectedItems.ElementAt(0).PersonId);
         Assert.Equal(2, SelectedItems.ElementAt(1).PersonId);
@@ -757,7 +757,7 @@
         // Act - Clear selection
         var selectColumn = cut.FindComponent<SelectColumn<Person>>();
 
-        await ClickOnRowAsync(cut, row: 0, col: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0, col: 0);
         await selectColumn.Instance.ClearSelectionAsync();
 
         // Assert - Selection is cleared
@@ -814,7 +814,7 @@
         // Act - Clear selection
         var selectColumn = cut.FindComponent<SelectColumn<Person>>();
 
-        await ClickOnRowAsync(cut, row: 0, col: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0, col: 0);
         await selectColumn.Instance.ClearSelectionAsync();
 
         // Assert - Selection is cleared
@@ -1038,7 +1038,7 @@
         );
 
         // Act - Click on Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
 
         // Assert - Verify row selection
         Assert.Empty(SelectedItems);
@@ -1296,18 +1296,18 @@
         Assert.Empty(SelectedItems);
 
         // Act - Click and select Row 0
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(cut.FindAll("svg[row-selected]"));
         Assert.Single(SelectedItems);
 
-        // Act - Click and select Row 1
-        await ClickOnRowAsync(cut, row: 0);
+     // Act - Click and select Row 1
+        await ClickOnRowAsync<Person>(cut, row: 0);
 
         Assert.Empty(SelectedItems);
     }
 
     [Fact]
-    public async Task FluentDataGrid_ColumSelect_MultiSelect_SelectedItems_PersistAcrossPagination()
+    public async Task FluentDataGrid_ColumnSelect_MultiSelect_SelectedItems_PersistAcrossPagination()
     {
         var items = new[]
         {
@@ -1331,8 +1331,8 @@
         <FluentPaginator State="@pagination" />
     </div>);
 
-    // Select an item on page 1
-        await ClickOnRowAsync(cut, row: 0);
+ // Select an item on page 1
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Single(SelectedItems);
         var firstSelectedId = SelectedItems.First().PersonId;
 
@@ -1346,7 +1346,7 @@
         Assert.Equal(firstSelectedId, SelectedItems.First().PersonId);
 
         // Select another item on page 2
-        await ClickOnRowAsync(cut, row: 0);
+        await ClickOnRowAsync<Person>(cut, row: 0);
         Assert.Equal(2, SelectedItems.Count());
     }
 
@@ -1452,31 +1452,6 @@
                           .ElementAt(row + 1);
             await item.Instance.HandleOnCellClickAsync();
             cut.FindComponent<FluentDataGrid<TGridItem>>().Render();
-        }
-    }
-
-    /// <summary>
-    /// Simulate a click on the DataGrid row number <paramref name="row"/>.
-    /// </summary>
-    /// <param name="cut"></param>
-    /// <param name="row"></param>
-    /// <param name="col"></param>
-    /// <returns></returns>
-    private async Task ClickOnRowAsync(IRenderedComponent<ContainerFragment> cut, int row, int? col = null)
-    {
-        if (col == null)
-        {
-            var item = cut.FindComponents<FluentDataGridRow<Person>>().ElementAt(row + 1);
-            await item.Instance.HandleOnRowClickAsync(item.Instance.RowId);
-            cut.FindComponent<FluentDataGrid<Person>>().Render();
-        }
-        else
-        {
-            var item = cut.FindComponents<FluentDataGridCell<Person>>()
-                          .Where(i => i.Instance.GridColumn == col + 1)
-                          .ElementAt(row + 1);
-            await item.Instance.HandleOnCellClickAsync();
-            cut.FindComponent<FluentDataGrid<Person>>().Render();
         }
     }
 


### PR DESCRIPTION
This is the v5 fix for #4596. It is extended to compare items (by using ItemKey) when items are being re-materialized when using paging/virtualization.

Also add tests for this.

Enhancements to selection logic:

* Introduced `EffectiveComparer` property in `SelectColumn`, which defaults to a new `ItemKeyEqualityComparer` when paging/virtualizing, allowing selection to be based on stable keys instead of object references. This ensures selection persists across pagination and rematerialization scenarios. [[1]](diffhunk://#diff-ffe1339ec5e9f02041f518eac2212fed34d5b7bea56bf46dd6100cf3ef683d9dR28-R30) [[2]](diffhunk://#diff-ffe1339ec5e9f02041f518eac2212fed34d5b7bea56bf46dd6100cf3ef683d9dR245-R271) [[3]](diffhunk://#diff-ffe1339ec5e9f02041f518eac2212fed34d5b7bea56bf46dd6100cf3ef683d9dR724-R751)
* Updated selection-related methods (`AddOrRemoveSelectedItemAsync`, `UpdateSelectedItemsAsync`, `GetDefaultChildContent`) to use `EffectiveComparer` for all equality checks, improving reliability of selection state. [[1]](diffhunk://#diff-ffe1339ec5e9f02041f518eac2212fed34d5b7bea56bf46dd6100cf3ef683d9dR377-R388) [[2]](diffhunk://#diff-ffe1339ec5e9f02041f518eac2212fed34d5b7bea56bf46dd6100cf3ef683d9dL410-R449) [[3]](diffhunk://#diff-ffe1339ec5e9f02041f518eac2212fed34d5b7bea56bf46dd6100cf3ef683d9dL479-R519) [[4]](diffhunk://#diff-ffe1339ec5e9f02041f518eac2212fed34d5b7bea56bf46dd6100cf3ef683d9dR532-R541)

Test coverage improvements:

* Added a new entity class `PersonEntity` for testing scenarios where items are re-materialized, and implemented tests to verify selection persistence and visual restoration across pagination with and without stable keys. [[1]](diffhunk://#diff-218f67348c0505dedc0a62e55e69ffffb381d1ffe7153a1130df9992315ff4a7R15-R26) [[2]](diffhunk://#diff-218f67348c0505dedc0a62e55e69ffffb381d1ffe7153a1130df9992315ff4a7R1309-R1419)
* Added a generic `ClickOnRowAsync<TGridItem>` helper to simplify row/cell click simulation in tests.

These changes collectively ensure that selection in the DataGrid is robust, especially in complex data scenarios involving paging, virtualization, and rematerialization.