### PR TITLE
[dev-v5][Docs] Add migration guide for FluentDrag components

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Drag/FluentDragDrop.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Drag/FluentDragDrop.md
@@ -44,3 +44,7 @@ This structure allows fully flexible layout editing with deep nesting and drag-a
 ## API FluentDragEventArgs
 
 {{ API Type=FluentDragEventArgs<int> }}
+
+## Migrating from v4
+
+{{ INCLUDE File=MigrationDrag }}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationDrag.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Migration/MigrationDrag.md
@@ -1,0 +1,61 @@
+---
+title: Migration FluentDragContainer and FluentDropZone
+route: /Migration/Drag
+hidden: true
+---
+
+### General changes 💥
+
+All events associated with this component have been updated to use `EventCallback<FluentDragEventArgs<TItem>>` instead of `Action<FluentDragEventArgs<TItem>>`. This change allows developers to use different method signatures and properly await tasks.
+
+```cs
+private void OnDropEnd(FluentDragEventArgs<string> e) { } // Possible in v4 & v5
+
+private Task OnDropEnd(FluentDragEventArgs<string> e) { } // Possible in v5
+
+private async Task OnRowDropEnd(FluentDragEventArgs<string> e) { } // Possible in v5
+```
+
+This change introduces minor breaking changes if these properties are assigned in C# code.
+
+```cs
+// v4
+component.OnDragEnter = (e) => { };
+
+// v5
+component.OnDragEnter = EventCallback.Factory.Create<FluentDragEventArgs<FormRow>>(this, (e) => { });
+```
+
+You also need to update your code if you are checking these properties for null.
+
+```cs
+// v4
+if (component.OnDragEnter != null) { }
+
+// v5
+if (component.OnDragEnter.HasDelegate) { }
+```
+
+#### Changed properties
+
+| V4 Property | V5 Property | Change |
+|-------------|-------------|--------|
+| `OnDragStart` (`Action<FluentDragEventArgs<TItem>>`) | `OnDragStart` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |
+| `OnDragEnd` (`Action<FluentDragEventArgs<TItem>>`) | `OnDragEnd` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |
+| `OnDragEnter` (`Action<FluentDragEventArgs<TItem>>`) | `OnDragEnter` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |
+| `OnDragOver` (`Action<FluentDragEventArgs<TItem>>`) | `OnDragOver` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |
+| `OnDragLeave` (`Action<FluentDragEventArgs<TItem>>`) | `OnDragLeave` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |
+| `OnDropEnd` (`Action<FluentDragEventArgs<TItem>>`) | `OnDropEnd` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |
+
+### FluentDropZone changes
+
+#### Changed properties
+
+| V4 Property | V5 Property | Change |
+|-------------|-------------|--------|
+| `OnDragStart` (`Action<FluentDragEventArgs<TItem>>`) | `OnDragStart` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |
+| `OnDragEnd` (`Action<FluentDragEventArgs<TItem>>`) | `OnDragEnd` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |
+| `OnDragEnter` (`Action<FluentDragEventArgs<TItem>>`) | `OnDragEnter` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |
+| `OnDragOver` (`Action<FluentDragEventArgs<TItem>>`) | `OnDragOver` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |
+| `OnDragLeave` (`Action<FluentDragEventArgs<TItem>>`) | `OnDragLeave` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |
+| `OnDropEnd` (`Action<FluentDragEventArgs<TItem>>`) | `OnDropEnd` (`EventCallback<FluentDragEventArgs<TItem>>`) | Switched from `Action` to `EventCallback` |

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/MigrationVersion5.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/MigrationVersion5.md
@@ -60,3 +60,7 @@ The categories these changes fall in are:
 ## FluentSelect
 
 {{ INCLUDE MigrationFluentSelect }}
+
+## FluentDragContainer and FluentDropZone
+
+{{ INCLUDE MigrationDrag }}


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds missing migration guide for `FluentDragContainer` and `FluentDropZone` which hightlights breaking changes from v4.

### 🎫 Issues



## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
