### PR TITLE
[dev-v5] Fix "checked" logic in FluentCheckbox to respect ThreeState parameter

### DIFF
--- a/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
+++ b/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
@@ -113,6 +113,7 @@ public partial class FluentCheckbox : FluentInputBase<bool>, IFluentComponentEle
         }
     }
 
+    //private bool _checked => ThreeState ? CheckState ?? Value : Value;
     private bool _checked => CheckState ?? Value;
 
     private bool _indeterminate => ThreeState

--- a/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
+++ b/src/Core/Components/Checkbox/FluentCheckbox.razor.cs
@@ -113,8 +113,7 @@ public partial class FluentCheckbox : FluentInputBase<bool>, IFluentComponentEle
         }
     }
 
-    //private bool _checked => ThreeState ? CheckState ?? Value : Value;
-    private bool _checked => CheckState ?? Value;
+    private bool _checked => ThreeState ? CheckState ?? Value : Value;
 
     private bool _indeterminate => ThreeState
         ? !CheckState.HasValue

--- a/tests/Core/Components/Checkbox/FluentCheckboxTests.razor
+++ b/tests/Core/Components/Checkbox/FluentCheckboxTests.razor
@@ -154,6 +154,24 @@
         Assert.Equal(expectedValue, value);
     }
 
+    // Line 116: private bool _checked => ThreeState ? CheckState ?? Value : Value;
+    [Theory]
+    [InlineData(true,  true,  false, true)]   // ThreeState=true,  CheckState=true  → _checked=true
+    [InlineData(true,  false, true,  false)]  // ThreeState=true,  CheckState=false → _checked=false
+    [InlineData(true,  null,  true,  true)]   // ThreeState=true,  CheckState=null  → falls back to Value=true
+    [InlineData(true,  null,  false, false)]  // ThreeState=true,  CheckState=null  → falls back to Value=false
+    [InlineData(false, null,  true,  true)]   // ThreeState=false, CheckState ignored → _checked=Value=true
+    [InlineData(false, null,  false, false)]  // ThreeState=false, CheckState ignored → _checked=Value=false
+    public void FluentCheckbox_Checked_ReflectsThreeStateLogic(bool threeState, bool? checkState, bool value, bool expectedChecked)
+    {
+        // Arrange && Act
+        var cut = Render(@<FluentCheckbox ThreeState="@threeState" CheckState="@checkState" Value="@value" />);
+
+        // Assert
+        var checkedAttr = cut.Find("fluent-checkbox").GetAttribute("checked");
+        Assert.Equal(expectedChecked ? "true" : "false", checkedAttr);
+    }
+
     [Theory]
     [InlineData(false, false, true)]
     [InlineData(false, true, false)]


### PR DESCRIPTION
# Fix "checked" logic in FluentCheckbox to respect ThreeState parameter

Enhance the "checked" logic in **FluentCheckbox** to correctly respect the **ThreeState** parameter. 
Add tests to validate the new logic and ensure expected behavior across different **CheckState** values.

See #4630