### PR TITLE
[dev-v5] DocGenerator: Ensure dllFile and xmlFile are absolute paths

### DIFF
--- a/examples/Tools/FluentUI.Demo.DocApiGen/Program.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Program.cs
@@ -45,6 +45,10 @@ public class Program
             return;
         }
 
+        // Ensure dllFile and xmlFile are absolute paths
+        dllFile = Path.IsPathRooted(dllFile) ? dllFile : Path.Combine(Directory.GetCurrentDirectory(), dllFile);
+        xmlFile = Path.IsPathRooted(xmlFile) ? xmlFile : Path.Combine(Directory.GetCurrentDirectory(), xmlFile);
+
         try
         {
             // Parse generation mode


### PR DESCRIPTION
# [dev-v5] DocGenerator: Ensure dllFile and xmlFile are absolute paths

Update the DocApiGen tool to ensure that the `dllFile` and `xmlFile` parameters are treated as absolute paths, preventing potential issues with relative paths during execution. This change enhances the reliability of the tool.

```bash
# Note: Update net9.0 paths to match NetVersion in Directory.Build.props (net8.0, net9.0, or net10.0)
dotnet run --xml "./Microsoft.FluentUI.AspNetCore.Components.xml" --dll "../../../src/Core/bin/Debug/net9.0/Microsoft.FluentUI.AspNetCore.Components.dll" --output "../../../examples/Demo/FluentUI.Demo.Client/wwwroot/api-comments-all.json" --format json --mode all
```