### PR TITLE
[Docs] Fix incorrect Icon in search after Navigation

### DIFF
--- a/examples/Demo/Shared/Shared/DemoSearch.razor
+++ b/examples/Demo/Shared/Shared/DemoSearch.razor
@@ -1,13 +1,13 @@
 ﻿<FluentAutocomplete @ref="_searchAutocomplete"
                     TOption="NavItem"
+                    Multiple="false"
                     Width="250px"
                     AutoComplete="off"
                     Placeholder="Type / to search..."
-                    MaximumSelectedOptions="1"
                     OptionText="@(item => item.Title)"
                     @bind-ValueText="@_searchTerm"
-                    @bind-SelectedOptions="_selectedOptions"
-                    @bind-SelectedOptions:after="HandleSearchClicked"
+                    @bind-SelectedOption="_selectedOption"
+                    @bind-SelectedOption:after="HandleSearchClicked"
                     OnOptionsSearch="@HandleSearchInput"
                     ShowOverlayOnEmptyResults="false">
     <OptionTemplate>

--- a/examples/Demo/Shared/Shared/DemoSearch.razor.cs
+++ b/examples/Demo/Shared/Shared/DemoSearch.razor.cs
@@ -21,7 +21,7 @@ public partial class DemoSearch : IAsyncDisposable
 
     private FluentAutocomplete<NavItem>? _searchAutocomplete = default!;
     private string? _searchTerm = "";
-    private IEnumerable<NavItem>? _selectedOptions = [];
+    private NavItem? _selectedOption = null;
 
     protected override void OnInitialized()
     {
@@ -57,8 +57,8 @@ public partial class DemoSearch : IAsyncDisposable
     private void HandleSearchClicked()
     {
         _searchTerm = null;
-        var targetHref = _selectedOptions?.SingleOrDefault()?.Href;
-        _selectedOptions = [];
+        var targetHref = _selectedOption?.Href;
+        _selectedOption = null;
         InvokeAsync(StateHasChanged);
 
         // Ignore clearing the search bar


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

Fix an issue where the 'X' icon would remain visible on the [Docs](https://www.fluentui-blazor.net/) Search input after a user has selected an item and navigated away. This is due to the check that the Autocomplete component does where with this component usage, this.SelectedOption is not null at this point.

Updating the component to use `Multiple="false"` fixes this issue and still allows for correct handling of navigation.

I had originally ran into this issue myself as when implementing a similar Navigation Search for my own project where I used the docs as a starting point for how best to achieve this with FluentUI.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Current Behaviour:
![fluentUI-Search-Icon-Before](https://github.com/user-attachments/assets/445f7468-9857-4193-8dc4-0a9c17895221)

Behaviour After Changes:
![fluentUI-Search-Icon-After](https://github.com/user-attachments/assets/da7a2e14-b2a7-4b0e-9ecc-c771ca8d6027)

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

Manually testing after making the change to see that the icon correctly updates to the search icon when navigating matching the expended behaviour as the search input text clears. Checked with both mouse clicks, and keyboard arrow keys + enter.

As this change is just to the docs page rather than a change to the component library itself, I don't believe there is any unit testings that covers this. However if I'm wrong, please just let me know and I'd be happy to add something in.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
