### PR TITLE
[SplashScreen] Mark sync methods as Obsolete

### DIFF
--- a/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
+++ b/examples/Demo/Shared/Microsoft.FluentUI.AspNetCore.Components.xml
@@ -3936,6 +3936,7 @@
             left (full height), right (full height)
             or screen middle (using Width and Height properties).
             HorizontalAlignment.Stretch is not supported for this property.
+            NOTE: Left/Right only works for Panels, not Dialogs, which are always centered.
             </summary>
         </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.DialogParameters.Title">
@@ -8532,6 +8533,12 @@
             <param name="force">If true, the total item count will be updated even if it is the same as the current value.</param>
             <returns></returns>
         </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.LibraryConfiguration">
+            <summary />
+        </member>
+        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.JSRuntime">
+            <summary />
+        </member>
         <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.AnchorId">
             <summary>
             Gets or sets the id of the component the popover is positioned relative to.
@@ -8610,19 +8617,26 @@
             By default, Escape
             </summary>
         </member>
-        <member name="P:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.CloseAndTabKeys">
-            <summary />
-        </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.OnInitialized">
             <summary />
         </member>
         <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.OnParametersSet">
             <summary />
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.CloseAsync">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.OnAfterRenderAsync(System.Boolean)">
             <summary />
         </member>
-        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.CloseOnKeyAsync(Microsoft.FluentUI.AspNetCore.Components.FluentKeyCodeEventArgs)">
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.CloseAsync">
+            <summary>
+            Closes the popover. Called from JavaScript keyboard navigation.
+            </summary>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.CloseOverlayAsync">
+            <summary>
+            Closes the popover and returns focus to the original element (used by the overlay on outside-click).
+            </summary>
+        </member>
+        <member name="M:Microsoft.FluentUI.AspNetCore.Components.FluentPopover.DisposeAsync">
             <summary />
         </member>
         <member name="T:Microsoft.FluentUI.AspNetCore.Components.FluentPresenceBadge">

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenCustom.razor
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenCustom.razor
@@ -1,9 +1,5 @@
 ﻿@inject IDialogService DialogService
 
-<FluentButton @onclick="@OpenSplashCustom" Appearance="Appearance.Accent">
-    Open splash screen
-</FluentButton>
-
 <FluentButton @onclick="@OpenSplashCustomAsync" Appearance="Appearance.Accent">
-    Open splash screen (async)
+    Open splash screen
 </FluentButton>

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenCustom.razor.cs
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenCustom.razor.cs
@@ -38,24 +38,6 @@ public partial class DialogSplashScreenCustom
         DialogResult result = await _dialog.Result;
         await HandleCustomSplashAsync(result);
     }
-    private void OpenSplashCustom()
-    {
-        DemoLogger.WriteLine($"Open custom splashscreen for 4 seconds");
-        DialogParameters<SplashScreenContent> parameters = new()
-        {
-            Content = new()
-            {
-                Title = "Water drinking 101",
-                LoadingText = "Filling the re-useable bottles...",
-                Message = (MarkupString)"Don't drink <strong>too</strong> much water!",
-                Logo = "_content/FluentUI.Demo.Shared/images/Splash_Corporation_logo.png",
-            },
-            Width = "500px",
-            Height = "300px",
-        };
-        DialogService.ShowSplashScreen<CustomSplashScreen>(this, HandleCustomSplashAsync, parameters);
-    }
-
     private async Task HandleCustomSplashAsync(DialogResult result)
     {
         await Task.Run(() => DemoLogger.WriteLine($"Custom splash closed"));

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor
@@ -1,9 +1,5 @@
 ﻿@inject IDialogService DialogService
 
-<FluentButton @onclick="@OpenSplashDefault" Appearance="Appearance.Accent">
-    Open splash screen
-</FluentButton>
-
 <FluentButton @onclick="@OpenSplashDefaultAsync" Appearance="Appearance.Accent">
-    Open splash screen (async)
+    Open splash screen
 </FluentButton>

--- a/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor.cs
+++ b/examples/Demo/Shared/Pages/SplashScreen/Examples/DialogSplashScreenDefault.razor.cs
@@ -47,26 +47,6 @@ public partial class DialogSplashScreenDefault
         await HandleDefaultSplashAsync(result);
     }
 
-    private void OpenSplashDefault()
-    {
-        DemoLogger.WriteLine($"Open default SplashScreen for 4 seconds");
-        DialogParameters<SplashScreenContent> parameters = new()
-        {
-            Content = new()
-            {
-                Title = "Core components",
-                SubTitle = "Microsoft Fluent UI Blazor library",
-                LoadingText = "Loading...",
-                Message = (MarkupString)"some <i>extra</i> text <strong>here</strong>",
-                Logo = FluentSplashScreen.LOGO,
-            },
-            Width = "640px",
-            Height = "480px",
-            Modal = true,
-        };
-        DialogService.ShowSplashScreen(this, HandleDefaultSplashAsync, parameters);
-    }
-
     private async Task HandleDefaultSplashAsync(DialogResult result)
     {
         await Task.Run(() => DemoLogger.WriteLine($"Default splash closed"));

--- a/examples/Demo/Shared/Pages/SplashScreen/SplashScreenPage.razor
+++ b/examples/Demo/Shared/Pages/SplashScreen/SplashScreenPage.razor
@@ -15,17 +15,20 @@
     To show a splash screen, the <code>DialogService</code> is used. The <code>DialogService</code> is a singleton service that can be injected
     into any page/component. It exposes the following methods to show a splash screen dialog:
     <ul>
-        <li><code>ShowSplashScreen</code> / <code>ShowSplashScreenAsync</code> (uses the <code>FluentSplashScreen</code> to show the dialog)</li>
+        <li><code>ShowSplashScreenAsync</code> (uses the <code>FluentSplashScreen</code> to show the dialog)</li>
         <li>
-            <code>ShowSplashScreen&lt;T&gt;</code> / <code>ShowSplashScreenAsync&lt;T&gt;</code> where T is a custom component which inherits the <code>FluentSplashScreen</code> component
+            <code>ShowSplashScreenAsync&lt;T&gt;</code> where T is a custom component which inherits the <code>FluentSplashScreen</code> component
             and implements <code>IDialogContentComponent&lt;SplashScreenContent&gt;</code> .</li>
     </ul>
 </p>
 <p>
-    Internally, the <code>ShowSplashScreen</code> methods call the <code>ShowDialog</code> methods. If is possible to directly call these methods and thereby have
-    access to all of the parameters. The <code>ShowSplashScreen</code> variants are just convenience methods that make ite easier to work with panels.
+    Internally, the <code>ShowSplashScreenAsync</code> methods call the <code>ShowDialogAsync</code> methods. If is possible to directly call these methods and thereby have
+    access to all of the parameters. The <code>ShowSplashScreenAsync</code> variants are just convenience methods that make ite easier to work with panels.
 </p>
 
+<FluentMessageBar Title="Warning" Intent="@MessageIntent.Warning">
+    Although the <code>DialogService</code> also exposes synchronous variants, we suggest not using them as they will be removed in the next major version.
+</FluentMessageBar>
 
 <h2 id="example">Examples</h2>
 

--- a/examples/Demo/Shared/Pages/SplashScreen/SplashScreenPage.razor
+++ b/examples/Demo/Shared/Pages/SplashScreen/SplashScreenPage.razor
@@ -27,7 +27,7 @@
 </p>
 
 <FluentMessageBar Title="Warning" Intent="@MessageIntent.Warning">
-    Although the <code>DialogService</code> also exposes synchronous variants, we suggest not using them as they will be removed in the next major version.
+    The <code>DialogService</code>'s synchronous methods are obsoleted and will be removed in the next major version (v5).
 </FluentMessageBar>
 
 <h2 id="example">Examples</h2>

--- a/src/Core/Components/Dialog/Services/DialogService-SplashScreen.cs
+++ b/src/Core/Components/Dialog/Services/DialogService-SplashScreen.cs
@@ -14,6 +14,7 @@ public partial class DialogService
     /// <param name="receiver">The component that receives the callback</param>
     /// <param name="callback">Name of the callback function</param>
     /// <param name="parameters"><see cref="SplashScreenContent"/> that holds the content to display</param>
+    [Obsolete("Use ShowSplashScreenAsync(object, Func, DialogParameters) instead.")]
     public void ShowSplashScreen(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
         => ShowSplashScreen<FluentSplashScreen>(receiver, callback, parameters);
 
@@ -23,6 +24,7 @@ public partial class DialogService
     /// <param name="receiver">The component that receives the callback</param>
     /// <param name="callback">Name of the callback function</param>
     /// <param name="parameters"><see cref="SplashScreenContent"/> that holds the content to display</param>
+    [Obsolete("Use ShowSplashScreenAsync<T>(object, Func, DialogParameters) instead.")]
     public void ShowSplashScreen<T>(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
         where T : IDialogContentComponent<SplashScreenContent>
         => ShowSplashScreen(typeof(T), receiver, callback, parameters);
@@ -34,6 +36,7 @@ public partial class DialogService
     /// <param name="receiver">The component that receives the callback</param>
     /// <param name="callback">Name of the callback function</param>
     /// <param name="parameters"><see cref="SplashScreenContent"/> that holds the content to display</param>
+    [Obsolete("Use ShowSplashScreenAsync(Type, object, Func, DialogParameters) instead.")]
     public void ShowSplashScreen(Type component, object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
     {
         DialogParameters dialogParameters = new()

--- a/src/Core/Components/Dialog/Services/IDialogService-SplashScreen.cs
+++ b/src/Core/Components/Dialog/Services/IDialogService-SplashScreen.cs
@@ -6,11 +6,14 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 
 public partial interface IDialogService
 {
+    [Obsolete("Use ShowSplashScreenAsync(object, Func, DialogParameters) instead.")]
     void ShowSplashScreen(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters);
 
+    [Obsolete("Use ShowSplashScreenAsync<T>(object, Func, DialogParameters) instead.")]
     void ShowSplashScreen<T>(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters)
         where T : IDialogContentComponent<SplashScreenContent>;
 
+    [Obsolete("Use ShowSplashScreenAsync(Type, object, Func, DialogParameters) instead.")]
     void ShowSplashScreen(Type component, object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters);
 
     Task<IDialogReference> ShowSplashScreenAsync(object receiver, Func<DialogResult, Task> callback, DialogParameters<SplashScreenContent> parameters);


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR marks all synchronous `ShowSplashScreen` methods as obsolete because they won't be in v5 anymore. In addition it also removes the broken sync SplashScreen samples from the demo site. I also updated the docs section with a warning for the synchrounous methods.

### 🎫 Issues

Related to #4637

## 👩‍💻 Reviewer Notes

This change will help users to switch to the async functions early on which will make the migration to v5 easier later on.


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
