### PR TITLE
[NavGroup] Fix disabled state for top-level `FluentNavGroup`

### DIFF
--- a/examples/Demo/Shared/Pages/NavMenu/Examples/NavMenuCollapsible.razor
+++ b/examples/Demo/Shared/Pages/NavMenu/Examples/NavMenuCollapsible.razor
@@ -20,6 +20,9 @@
                 <FluentNavLink Icon="@(new Icons.Regular.Size24.LeafOne())" Tooltip="Item 5.1 tooltip">Item 5.1</FluentNavLink>
             </FluentNavGroup>
             <FluentNavLink Icon="@(new Icons.Regular.Size24.CalendarAgenda())" Disabled="true" Href="https://microsoft.com" Tooltip="Item 6 tooltip">Item 6</FluentNavLink>
+            <FluentNavGroup Title="Item 7" Tooltip="Item 7 tooltip" Disabled="true">
+                <FluentNavLink Icon="@(new Icons.Regular.Size24.LeafOne())" Tooltip="Item 7.1 tooltip">Item 7.1</FluentNavLink>
+            </FluentNavGroup>
         </FluentNavMenu>
     </div>
     <div style="width: 100%;">

--- a/src/Core/Components/NavMenu/FluentNavGroup.razor.cs
+++ b/src/Core/Components/NavMenu/FluentNavGroup.razor.cs
@@ -104,6 +104,10 @@ public partial class FluentNavGroup : FluentNavBase
 
     private async Task ToggleExpandedAsync()
     {
+        if (Disabled)
+        {
+            return;
+        }
 
         if (!Owner.Expanded && Owner.CollapsedChildNavigation)
         {

--- a/src/Core/Components/NavMenu/FluentNavGroup.razor.css
+++ b/src/Core/Components/NavMenu/FluentNavGroup.razor.css
@@ -14,16 +14,6 @@
     min-width: 20px;
 }
 
-::deep .fluent-nav-group.disabled {
-    color: var(--neutral-fill-secondary-rest) !important;
-    pointer-events: none;
-}
-
-    ::deep .fluent-nav-group.disabled .fluent-nav-icon {
-        fill: var(--neutral-stroke-rest) !important;
-    }
-
-
 /* Group expand/collapse */
 ::deep .expand-collapse-button {
     position: absolute;

--- a/src/Core/Components/NavMenu/FluentNavMenu.razor.css
+++ b/src/Core/Components/NavMenu/FluentNavMenu.razor.css
@@ -1,7 +1,6 @@
 /*  NavMenu */
 .fluent-nav-menu {
     padding: 0 2px;
-
 }
 
 ::deep .fluent-nav-item.expander:focus-within {
@@ -15,24 +14,33 @@
 }
 
     /* Hover and active highlighting */
-    ::deep .fluent-nav-item .positioning-region:hover:not(:has(.disabled)) {
+    ::deep .fluent-nav-item:not(.disabled) .positioning-region:hover:not(:has(.disabled)) {
         cursor: pointer;
         background: var(--neutral-fill-secondary-rest);
     }
 
-        /* Active item indicator */
-        ::deep .fluent-nav-item .active .positioning-region::before {
-            content: "";
-            display: block;
-            position: absolute;
-            right: unset;
-            width: 3px;
-            height: calc(((var(--base-height-multiplier) + var(--density)) * var(--design-unit) / 2) * 1px);
-            background: var(--accent-fill-rest);
-            border-radius: calc(var(--control-corner-radius) * 1px);
-            margin: calc(var(--design-unit) * 2px) 2px;
-            z-index: 5;
-        }
+    /* Active item indicator */
+    ::deep .fluent-nav-item .active .positioning-region::before {
+        content: "";
+        display: block;
+        position: absolute;
+        right: unset;
+        width: 3px;
+        height: calc(((var(--base-height-multiplier) + var(--density)) * var(--design-unit) / 2) * 1px);
+        background: var(--accent-fill-rest);
+        border-radius: calc(var(--control-corner-radius) * 1px);
+        margin: calc(var(--design-unit) * 2px) 2px;
+        z-index: 5;
+    }
+
+::deep .fluent-nav-group.disabled {
+    color: var(--neutral-fill-secondary-rest) !important;
+    pointer-events: none;
+}
+
+    ::deep .fluent-nav-group.disabled .fluent-nav-icon {
+        fill: var(--neutral-stroke-rest) !important;
+    }
 
 [dir='rtl'] * ::deep .fluent-nav-item a.active .positioning-region::before {
     left: unset;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes the disabled state for top-level `FluentNavGroup` elements. When you had a `FluentNavGroup` with `Disabled="true"` on the top level of `FluentNavMenu` then it was still possible to open it. 

Before:

<img width="621" height="581" alt="before" src="https://github.com/user-attachments/assets/9e4c2d5e-8d14-4460-8661-fe601cfb9615" />

After:

<img width="495" height="608" alt="after" src="https://github.com/user-attachments/assets/9d99404d-2232-467d-9384-e495b4803a26" />


### 🎫 Issues

Fixes #4645 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
