### PR TITLE
[dev-v5] FluentLink with OnClick - Update styles for better hover effects

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Link/Examples/LinkWithIcons.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Link/Examples/LinkWithIcons.razor
@@ -1,4 +1,10 @@
 ﻿<FluentStack Orientation="Orientation.Vertical">
-	<FluentLink Href="link#link-with-icons" IconStart="@(new Icons.Regular.Size16.Link())">Link with icon at start</FluentLink>
-	<FluentLink Href="link#link-with-icons" IconEnd="@(new Icons.Regular.Size16.Bookmark().WithColor(Color.Success))">Link with icon at end</FluentLink>
+    <FluentLink OnClick="@(() => Console.WriteLine("Link with icon at start clicked"))"
+                IconStart="@(new Icons.Regular.Size16.Link())">
+        Link with icon at start
+    </FluentLink>
+    <FluentLink OnClick="@(() => Console.WriteLine("Link with icon at end clicked"))"
+                IconEnd="@(new Icons.Regular.Size16.Bookmark().WithColor(Color.Success))">
+        Link with icon at end
+    </FluentLink>
 </FluentStack>

--- a/src/Core/Components/Link/FluentLink.razor
+++ b/src/Core/Components/Link/FluentLink.razor
@@ -13,6 +13,7 @@
 			 id="@Id"
 			 class="@ClassValue"
 			 style="@StyleValue"
+             clickable="@OnClick.HasDelegate"
 			 @onclick="@OnClickHandlerAsync"
 			 @attributes="AdditionalAttributes">
 	@if (IconStart is not null)

--- a/src/Core/Components/Link/FluentLink.razor.css
+++ b/src/Core/Components/Link/FluentLink.razor.css
@@ -1,3 +1,15 @@
 [inline]:hover {
   text-decoration: underline;
 }
+
+fluent-link[clickable] {
+    color: var(--colorBrandForegroundLink);
+    text-decoration: none;
+    text-decoration-thickness: var(--strokeWidthThin);
+}
+
+fluent-link[clickable]:hover {
+    color: var(--colorBrandForegroundLinkHover);
+    outline: none;
+    text-decoration-line: underline;
+}


### PR DESCRIPTION
# FluentLink with OnClick - Update styles for better hover effects

Refactor FluentLink component to support clickable links with OnClick events and update styles for better hover effects

## Example
```razor
<FluentLink OnClick="@(() => Console.WriteLine("Link with icon at start clicked"))"
            IconStart="@(new Icons.Regular.Size16.Link())">
    Link with icon at start
</FluentLink>
<FluentLink OnClick="@(() => Console.WriteLine("Link with icon at end clicked"))"
            IconEnd="@(new Icons.Regular.Size16.Bookmark().WithColor(Color.Success))">
    Link with icon at end
</FluentLink>
```

## Before

<img width="206" height="61" alt="{7B3826DB-4E64-4AE9-9A18-80CD3BA704CF}" src="https://github.com/user-attachments/assets/5bc8920c-95f8-4fa2-837a-621267738795" />


## After

<img width="217" height="66" alt="{BC583166-046B-492C-9777-FF5011A97200}" src="https://github.com/user-attachments/assets/3517f181-61fd-4eec-94eb-bb579387724b" />
