### PR TITLE
[dev-v5][Docs] Add table with default translation key value pairs

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Examples/LocalizationDefaultTranslations.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Examples/LocalizationDefaultTranslations.razor
@@ -1,5 +1,4 @@
 ﻿@using System.Resources
-@using System.Reflection
 @using System.Globalization
 @using System.Collections
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Examples/LocalizationDefaultTranslations.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Examples/LocalizationDefaultTranslations.razor
@@ -1,0 +1,52 @@
+﻿@using System.Resources
+@using System.Reflection
+@using System.Globalization
+@using System.Collections
+
+<table>
+    <thead>
+        <tr>
+            <th>Key</th>
+            <th>Default translation</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var entry in _localizedStrings)
+        {
+            <tr>
+                <td>@entry.Key</td>
+                <td>@entry.Value</td>
+            </tr>
+        }
+    </tbody>
+</table>
+
+
+
+@code {
+
+    private Dictionary<string, string> _localizedStrings = [];
+
+    protected override Task OnInitializedAsync()
+    {
+        var resourceManager = Microsoft.FluentUI.AspNetCore.Components.Localization.LanguageResource.ResourceManager;
+        var culture = CultureInfo.InvariantCulture;
+        ResourceSet? resourceSet = resourceManager.GetResourceSet(culture, true, true);
+
+        if (resourceSet is not null)
+        {
+            _localizedStrings = resourceSet
+                .Cast<DictionaryEntry>()
+                .Where(e => e.Value is string)
+                .OrderBy(x => x.Key)
+                .ToDictionary(
+                    e => (string)e.Key,
+                    e => e.Value as string ?? string.Empty
+                );
+
+        }
+
+        return base.OnInitializedAsync();
+    }
+
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Localization.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Localization.md
@@ -128,3 +128,7 @@ You can use an embedded resource to store your translations.
        }
    }
    ```
+
+   ## Default translations
+
+   {{ LocalizationDefaultTranslations SourceCode=false }}


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds a table with all available key/value pairs which can be translated. This makes it easier to find the corresponding keys during development without the need to dig into the source code.

<img width="757" height="793" alt="grafik" src="https://github.com/user-attachments/assets/b226776f-e685-4e6b-a96a-1c05657d66cc" />





## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [ ] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
