### PR TITLE
[dev-v5] [List] Refactor OptionSelectedComparer to use IEqualityComparer

### DIFF
--- a/src/Core/Components/DateTime/FluentTimePicker.razor
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor
@@ -23,7 +23,7 @@
                     @onkeydown="@KeyDownHandlerAsync"
                     OptionText="@(i => i?.ToString(TimePattern))"
                     OptionValueToString="@(i => FormatValueAsString(i))"
-                    OptionSelectedComparer="@((i, j) => i?.Hour == j?.Hour && i?.Minute == j?.Minute)"
+                    OptionSelectedComparer="@TimeComparer"
                     OptionDisabled="@DisableHourHandler"
                     Required="@Required"
                     Indicator="@(new CoreIcons.Regular.Size20.Clock().WithColor("var(--colorNeutralForeground3)"))"

--- a/src/Core/Components/DateTime/FluentTimePicker.razor.cs
+++ b/src/Core/Components/DateTime/FluentTimePicker.razor.cs
@@ -14,6 +14,7 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// <summary />
 public partial class FluentTimePicker<TValue> : FluentInputBase<TValue>
 {
+    private static readonly IEqualityComparer<DateTime?> TimeComparer = new TimeEqualityComparer();
     private DateTime DefaultTime => Culture.Calendar.MinSupportedDateTime;
     private FluentCombobox<DateTime?, DateTime?> _fluentCombobox = default!;
 
@@ -243,6 +244,19 @@ public partial class FluentTimePicker<TValue> : FluentInputBase<TValue>
                 ListAppearance.Transparent => TextInputAppearance.Underline,
                 _ => TextInputAppearance.Outline,
             };
+        }
+    }
+
+    private sealed class TimeEqualityComparer : IEqualityComparer<DateTime?>
+    {
+        public bool Equals(DateTime? x, DateTime? y)
+        {
+            return x?.Hour == y?.Hour && x?.Minute == y?.Minute;
+        }
+
+        public int GetHashCode(DateTime? obj)
+        {
+            return obj is null ? 0 : HashCode.Combine(obj.Value.Hour, obj.Value.Minute);
         }
     }
 }

--- a/src/Core/Components/List/FluentListBase.razor.cs
+++ b/src/Core/Components/List/FluentListBase.razor.cs
@@ -110,10 +110,10 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
     public virtual Func<TOption?, bool>? OptionDisabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the function used to determine whether two options are considered equal for selection purposes.
+    /// Gets or sets the equality comparer used to determine whether two options are considered equal for selection purposes.
     /// </summary>
     [Parameter]
-    public virtual Func<TValue?, TValue?, bool>? OptionSelectedComparer { get; set; }
+    public virtual IEqualityComparer<TOption>? OptionSelectedComparer { get; set; }
 
     /// <inheritdoc cref="ITooltipComponent.Tooltip" />
     [Parameter]
@@ -167,6 +167,17 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
     }
 
     /// <summary />
+    bool IInternalListBase<TValue>.AreValuesEqual(TValue? value1, TValue? value2)
+    {
+        if (OptionSelectedComparer != null && value1 is TOption option1 && value2 is TOption option2)
+        {
+            return OptionSelectedComparer.Equals(option1, option2);
+        }
+
+        return EqualityComparer<TValue>.Default.Equals(value1, value2);
+    }
+
+    /// <summary />
     protected virtual bool GetOptionSelected(TOption? item)
     {
         if (item == null)
@@ -179,16 +190,16 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
         {
             if (OptionSelectedComparer != null)
             {
-                return SelectedItems?.Any(selectedItem => OptionSelectedComparer(GetOptionValue(item), GetOptionValue(selectedItem))) ?? false;
+                return SelectedItems?.Any(selectedItem => OptionSelectedComparer.Equals(item!, selectedItem!)) ?? false;
             }
 
             return SelectedItems?.Contains(item) ?? false;
         }
 
         // Single item
-        if (OptionSelectedComparer != null)
+        if (OptionSelectedComparer != null && CurrentValue is TOption currentAsOption)
         {
-            return OptionSelectedComparer(GetOptionValue(item), CurrentValue);
+            return OptionSelectedComparer.Equals(item!, currentAsOption);
         }
 
         return Equals(GetOptionValue(item), CurrentValue);

--- a/src/Core/Components/List/FluentListBase.razor.cs
+++ b/src/Core/Components/List/FluentListBase.razor.cs
@@ -190,7 +190,7 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
         {
             if (OptionSelectedComparer != null)
             {
-                return SelectedItems?.Any(selectedItem => OptionSelectedComparer.Equals(item!, selectedItem!)) ?? false;
+                return SelectedItems?.Any(selectedItem => OptionSelectedComparer.Equals(item, selectedItem)) ?? false;
             }
 
             return SelectedItems?.Contains(item) ?? false;
@@ -199,7 +199,7 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
         // Single item
         if (OptionSelectedComparer != null && CurrentValue is TOption currentAsOption)
         {
-            return OptionSelectedComparer.Equals(item!, currentAsOption);
+            return OptionSelectedComparer.Equals(item, currentAsOption);
         }
 
         return Equals(GetOptionValue(item), CurrentValue);

--- a/src/Core/Components/List/FluentOption.razor.cs
+++ b/src/Core/Components/List/FluentOption.razor.cs
@@ -115,12 +115,10 @@ public partial class FluentOption<TValue> : FluentComponentBase
         {
             InternalListContext.AddOption(this);
 
-            // Use OptionSelectedComparer if available, otherwise fallback to EqualityComparer<TValue>.Default
+            // Use AreValuesEqual to check if the option's value matches the list's current value
             if (Value is not null)
             {
-                var comparer = InternalListContext.ListComponent.OptionSelectedComparer;
-                if ((comparer != null && comparer(InternalListContext.ListComponent.Value, Value)) ||
-                    (comparer == null && EqualityComparer<TValue>.Default.Equals(InternalListContext.ListComponent.Value, Value)))
+                if (InternalListContext.ListComponent.AreValuesEqual(InternalListContext.ListComponent.Value, Value))
                 {
                     Selected = true;
                 }

--- a/src/Core/Components/List/IInternalListBase.cs
+++ b/src/Core/Components/List/IInternalListBase.cs
@@ -10,7 +10,7 @@ internal interface IInternalListBase<TValue>
 
     string? RemoveOption(FluentOption<TValue> option);
 
-    Func<TValue?, TValue?, bool>? OptionSelectedComparer { get; set; }
+    bool AreValuesEqual(TValue? value1, TValue? value2);
 
     Func<TValue?, string>? OptionValueToString { get; set; }
 

--- a/tests/Core/Components/List/FluentListboxTests.razor
+++ b/tests/Core/Components/List/FluentListboxTests.razor
@@ -208,7 +208,7 @@
             Id="MyList"
             Multiple="true"
             Items="@Digits"
-            OptionSelectedComparer="@((i, j) => string.Compare(i, j, StringComparison.InvariantCultureIgnoreCase) == 0)"
+            OptionSelectedComparer="@(StringComparer.InvariantCultureIgnoreCase)"
             @bind-Value="@value"
             @bind-SelectedItems="@selectedItems" />);
 

--- a/tests/Core/Components/List/FluentSelectTests.razor
+++ b/tests/Core/Components/List/FluentSelectTests.razor
@@ -209,7 +209,7 @@
             Id="MyList"
             Multiple="true"
             Items="@Digits"
-            OptionSelectedComparer="@((i, j) => string.Compare(i, j, StringComparison.InvariantCultureIgnoreCase) == 0)"
+            OptionSelectedComparer="@(StringComparer.InvariantCultureIgnoreCase)"
             @bind-Value="@value"
             @bind-SelectedItems="@selectedItems" />);
 


### PR DESCRIPTION
# [dev-v5] [List] Refactor OptionSelectedComparer to use IEqualityComparer

Improve comparison logic for option selection by refactoring `OptionSelectedComparer` to utilize `IEqualityComparer`. This change enhances the clarity and maintainability of the code while ensuring consistent equality checks for options. No breaking changes introduced.

## Unit Tests

No changes
