### PR TITLE
[dev-v5][Paginator] Add missing localizable strings 

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Paginator/FluentPaginatorPage.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Paginator/FluentPaginatorPage.md
@@ -21,8 +21,8 @@ The following values can be localized:
 - Paginator_GoNextPage - Go to next page
 - Paginator_GoPreviousPage - Go to previous page
 - Paginator_Status - Page {0} of {1}
-- Paginator_SummaryItem - item
-- Paginator_SummaryItems - items
+- Paginator_SummaryItem - {0} item
+- Paginator_SummaryItems - {0} items
 - Paginator_SummaryNoItems - No items
 
 _At a later date, point to example usage on Icon/Emoji explore  as well_

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Paginator/FluentPaginatorPage.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Paginator/FluentPaginatorPage.md
@@ -11,6 +11,20 @@ navigating through a collection of items. It is mostly being used in
 combination with a `FluentDataGrid`. See the examples on the [DataGrid](/DataGrid)
 page for more information.
 
+## Localization
+
+The Paginator has a number of strings that are used in the UI. These can be changed by leveraging the built-in [localization](/localization) functionality.
+The following values can be localized:
+
+- Paginator_GoFirstPage - Go to first page
+- Paginator_GoLastPage - Go to last page
+- Paginator_GoNextPage - Go to next page
+- Paginator_GoPreviousPage - Go to previous page
+- Paginator_Status - Page {0} of {1}
+- Paginator_SummaryItem - item
+- Paginator_SummaryItems - items
+- Paginator_SummaryNoItems - No items
+
 _At a later date, point to example usage on Icon/Emoji explore  as well_
 
 ## API FluentPaginator

--- a/src/Core/Components/Pagination/FluentPaginator.razor
+++ b/src/Core/Components/Pagination/FluentPaginator.razor
@@ -14,17 +14,17 @@
             }
             else
             {
-                if (State.TotalItemCount == 0)
+                @if (State.TotalItemCount == 0)
                 {
                     <strong>@Localizer[Localization.LanguageResource.Paginator_SummaryNoItems]</strong>
                 }
                 else if (State.TotalItemCount == 1)
                 {
-                    <strong>@($"{State.TotalItemCount} {Localizer[Localization.LanguageResource.Paginator_SummaryItem]}")</strong>
+                    <strong>@(string.Format(CultureInfo.InvariantCulture, Localizer[Localization.LanguageResource.Paginator_SummaryItem, State.TotalItemCount))</strong>
                 }
                 else
                 {
-                    <strong>@($"{State.TotalItemCount} {Localizer[Localization.LanguageResource.Paginator_SummaryItems]}")</strong>
+                    <strong>@(string.Format(CultureInfo.InvariantCulture, Localizer[Localization.LanguageResource.Paginator_SummaryItems, State.TotalItemCount))</strong>
                 }
             }
         </div>

--- a/src/Core/Components/Pagination/FluentPaginator.razor
+++ b/src/Core/Components/Pagination/FluentPaginator.razor
@@ -14,7 +14,18 @@
             }
             else
             {
-                <text><strong>@State.TotalItemCount</strong> items</text>
+                if (State.TotalItemCount == 0)
+                {
+                    <strong>@Localizer[Localization.LanguageResource.Paginator_SummaryNoItems]</strong>
+                }
+                else if (State.TotalItemCount == 1)
+                {
+                    <strong>@($"{State.TotalItemCount} {Localizer[Localization.LanguageResource.Paginator_SummaryItem]}")</strong>
+                }
+                else
+                {
+                    <strong>@($"{State.TotalItemCount} {Localizer[Localization.LanguageResource.Paginator_SummaryItems]}")</strong>
+                }
             }
         </div>
         <nav role="navigation" class="paginator-nav">

--- a/src/Core/Components/Pagination/FluentPaginator.razor
+++ b/src/Core/Components/Pagination/FluentPaginator.razor
@@ -20,11 +20,11 @@
                 }
                 else if (State.TotalItemCount == 1)
                 {
-                    <strong>@(string.Format(CultureInfo.InvariantCulture, Localizer[Localization.LanguageResource.Paginator_SummaryItem, State.TotalItemCount))</strong>
+                    <strong>@(string.Format(CultureInfo.InvariantCulture, Localizer[Localization.LanguageResource.Paginator_SummaryItem], State.TotalItemCount))</strong>
                 }
                 else
                 {
-                    <strong>@(string.Format(CultureInfo.InvariantCulture, Localizer[Localization.LanguageResource.Paginator_SummaryItems, State.TotalItemCount))</strong>
+                    <strong>@(string.Format(CultureInfo.InvariantCulture, Localizer[Localization.LanguageResource.Paginator_SummaryItems], State.TotalItemCount))</strong>
                 }
             }
         </div>

--- a/src/Core/Localization/LanguageResource.resx
+++ b/src/Core/Localization/LanguageResource.resx
@@ -343,10 +343,10 @@
     <value>Toggle nesting</value>
   </data>
   <data name="Paginator_SummaryItem" xml:space="preserve">
-    <value>item</value>
+    <value>{0} item</value>
   </data>
   <data name="Paginator_SummaryItems" xml:space="preserve">
-    <value>items</value>
+    <value>{0} items</value>
   </data>
   <data name="Paginator_SummaryNoItems" xml:space="preserve">
     <value>No items</value>

--- a/src/Core/Localization/LanguageResource.resx
+++ b/src/Core/Localization/LanguageResource.resx
@@ -342,4 +342,13 @@
   <data name="DataGrid_ToggleNesting" xml:space="preserve">
     <value>Toggle nesting</value>
   </data>
+  <data name="Paginator_SummaryItem" xml:space="preserve">
+    <value>item</value>
+  </data>
+  <data name="Paginator_SummaryItems" xml:space="preserve">
+    <value>items</value>
+  </data>
+  <data name="Paginator_SummaryNoItems" xml:space="preserve">
+    <value>No items</value>
+  </data>
 </root>

--- a/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_Renders_CustomPaginationTextTemplate.verified.razor.html
+++ b/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_Renders_CustomPaginationTextTemplate.verified.razor.html
@@ -1,31 +1,35 @@
-
-<div class="fluent-paginator">
-  <div class="summary">
-    <strong>100</strong>
-    items</div>
-  <nav role="navigation" class="paginator-nav">
-    <fluent-button icon-only="" disabled="" title="Go to first page" blazor:onclick="x" aria-label="Go to first page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M11.35 15.85a.5.5 0 0 1-.7 0L5.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L6.2 10l5.16 5.15c.2.2.2.5 0 .7Zm4 0a.5.5 0 0 1-.7 0L9.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L10.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
-      </svg>
-    </fluent-button>
-    <fluent-button icon-only="" disabled="" title="Go to previous page" blazor:onclick="x" aria-label="Go to previous page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
-      </svg>
-    </fluent-button>
-    <div class="pagination-text">
-      <span class="custom-pagination-text">Page 1 of 10</span>
-    </div>
-    <fluent-button icon-only="" title="Go to next page" blazor:onclick="x" aria-label="Go to next page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"></path>
-      </svg>
-    </fluent-button>
-    <fluent-button icon-only="" title="Go to last page" blazor:onclick="x" aria-label="Go to last page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M8.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L13.8 10 8.65 4.85a.5.5 0 0 1 0-.7Zm-4 0c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L9.8 10 4.65 4.85a.5.5 0 0 1 0-.7Z"></path>
-      </svg>
-    </fluent-button>
-  </nav>
-</div>
+<html>
+	<head></head>
+	<body>
+		<div class="fluent-paginator">
+			<div class="summary">
+				<strong>100 items</strong>
+			</div>
+			<nav role="navigation" class="paginator-nav">
+				<fluent-button icon-only="" disabled="" title="Go to first page" blazor:onclick="x" aria-label="Go to first page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M11.35 15.85a.5.5 0 0 1-.7 0L5.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L6.2 10l5.16 5.15c.2.2.2.5 0 .7Zm4 0a.5.5 0 0 1-.7 0L9.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L10.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
+					</svg>
+				</fluent-button>
+				<fluent-button icon-only="" disabled="" title="Go to previous page" blazor:onclick="x" aria-label="Go to previous page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
+					</svg>
+				</fluent-button>
+				<div class="pagination-text">
+					<span class="custom-pagination-text">Page 1 of 10</span>
+				</div>
+				<fluent-button icon-only="" title="Go to next page" blazor:onclick="x" aria-label="Go to next page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"></path>
+					</svg>
+				</fluent-button>
+				<fluent-button icon-only="" title="Go to last page" blazor:onclick="x" aria-label="Go to last page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M8.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L13.8 10 8.65 4.85a.5.5 0 0 1 0-.7Zm-4 0c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L9.8 10 4.65 4.85a.5.5 0 0 1 0-.7Z"></path>
+					</svg>
+				</fluent-button>
+			</nav>
+		</div>
+	</body>
+</html>

--- a/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_Renders_WithDefaultState.verified.razor.html
+++ b/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_Renders_WithDefaultState.verified.razor.html
@@ -1,29 +1,33 @@
-
-<div class="fluent-paginator">
-  <div class="summary">
-    <strong>100</strong>
-    items</div>
-  <nav role="navigation" class="paginator-nav">
-    <fluent-button icon-only="" disabled="" title="Go to first page" blazor:onclick="x" aria-label="Go to first page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M11.35 15.85a.5.5 0 0 1-.7 0L5.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L6.2 10l5.16 5.15c.2.2.2.5 0 .7Zm4 0a.5.5 0 0 1-.7 0L9.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L10.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
-      </svg>
-    </fluent-button>
-    <fluent-button icon-only="" disabled="" title="Go to previous page" blazor:onclick="x" aria-label="Go to previous page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
-      </svg>
-    </fluent-button>
-    <div class="pagination-text">Page 1 of 10</div>
-    <fluent-button icon-only="" title="Go to next page" blazor:onclick="x" aria-label="Go to next page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"></path>
-      </svg>
-    </fluent-button>
-    <fluent-button icon-only="" title="Go to last page" blazor:onclick="x" aria-label="Go to last page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M8.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L13.8 10 8.65 4.85a.5.5 0 0 1 0-.7Zm-4 0c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L9.8 10 4.65 4.85a.5.5 0 0 1 0-.7Z"></path>
-      </svg>
-    </fluent-button>
-  </nav>
-</div>
+<html>
+	<head></head>
+	<body>
+		<div class="fluent-paginator">
+			<div class="summary">
+				<strong>100 items</strong>
+			</div>
+			<nav role="navigation" class="paginator-nav">
+				<fluent-button icon-only="" disabled="" title="Go to first page" blazor:onclick="x" aria-label="Go to first page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M11.35 15.85a.5.5 0 0 1-.7 0L5.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L6.2 10l5.16 5.15c.2.2.2.5 0 .7Zm4 0a.5.5 0 0 1-.7 0L9.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L10.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
+					</svg>
+				</fluent-button>
+				<fluent-button icon-only="" disabled="" title="Go to previous page" blazor:onclick="x" aria-label="Go to previous page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
+					</svg>
+				</fluent-button>
+				<div class="pagination-text">Page 1 of 10</div>
+				<fluent-button icon-only="" title="Go to next page" blazor:onclick="x" aria-label="Go to next page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"></path>
+					</svg>
+				</fluent-button>
+				<fluent-button icon-only="" title="Go to last page" blazor:onclick="x" aria-label="Go to last page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M8.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L13.8 10 8.65 4.85a.5.5 0 0 1 0-.7Zm-4 0c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L9.8 10 4.65 4.85a.5.5 0 0 1 0-.7Z"></path>
+					</svg>
+				</fluent-button>
+			</nav>
+		</div>
+	</body>
+</html>

--- a/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_SetItemsPerPage.verified.razor.html
+++ b/tests/Core/Components/Paginator/FluentPaginatorTests.FluentPaginator_SetItemsPerPage.verified.razor.html
@@ -1,29 +1,33 @@
-
-<div class="fluent-paginator">
-  <div class="summary">
-    <strong>20</strong>
-    items</div>
-  <nav role="navigation" class="paginator-nav">
-    <fluent-button icon-only="" disabled="" title="Go to first page" blazor:onclick="x" aria-label="Go to first page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M11.35 15.85a.5.5 0 0 1-.7 0L5.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L6.2 10l5.16 5.15c.2.2.2.5 0 .7Zm4 0a.5.5 0 0 1-.7 0L9.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L10.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
-      </svg>
-    </fluent-button>
-    <fluent-button icon-only="" disabled="" title="Go to previous page" blazor:onclick="x" aria-label="Go to previous page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
-      </svg>
-    </fluent-button>
-    <div class="pagination-text">Page 1 of 4</div>
-    <fluent-button icon-only="" title="Go to next page" blazor:onclick="x" aria-label="Go to next page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"></path>
-      </svg>
-    </fluent-button>
-    <fluent-button icon-only="" title="Go to last page" blazor:onclick="x" aria-label="Go to last page">
-      <svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x">
-        <path d="M8.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L13.8 10 8.65 4.85a.5.5 0 0 1 0-.7Zm-4 0c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L9.8 10 4.65 4.85a.5.5 0 0 1 0-.7Z"></path>
-      </svg>
-    </fluent-button>
-  </nav>
-</div>
+<html>
+	<head></head>
+	<body>
+		<div class="fluent-paginator">
+			<div class="summary">
+				<strong>20 items</strong>
+			</div>
+			<nav role="navigation" class="paginator-nav">
+				<fluent-button icon-only="" disabled="" title="Go to first page" blazor:onclick="x" aria-label="Go to first page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M11.35 15.85a.5.5 0 0 1-.7 0L5.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L6.2 10l5.16 5.15c.2.2.2.5 0 .7Zm4 0a.5.5 0 0 1-.7 0L9.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L10.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
+					</svg>
+				</fluent-button>
+				<fluent-button icon-only="" disabled="" title="Go to previous page" blazor:onclick="x" aria-label="Go to previous page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M12.35 15.85a.5.5 0 0 1-.7 0L6.16 10.4a.55.55 0 0 1 0-.78l5.49-5.46a.5.5 0 1 1 .7.7L7.2 10l5.16 5.15c.2.2.2.5 0 .7Z"></path>
+					</svg>
+				</fluent-button>
+				<div class="pagination-text">Page 1 of 4</div>
+				<fluent-button icon-only="" title="Go to next page" blazor:onclick="x" aria-label="Go to next page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M7.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L12.8 10 7.65 4.85a.5.5 0 0 1 0-.7Z"></path>
+					</svg>
+				</fluent-button>
+				<fluent-button icon-only="" title="Go to last page" blazor:onclick="x" aria-label="Go to last page">
+					<svg style="width: 20px; fill: var(--colorBrandForeground1);" focusable="false" viewBox="0 0 20 20" aria-hidden="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
+						<path d="M8.65 4.15c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L13.8 10 8.65 4.85a.5.5 0 0 1 0-.7Zm-4 0c.2-.2.5-.2.7 0l5.49 5.46c.21.22.21.57 0 .78l-5.49 5.46a.5.5 0 0 1-.7-.7L9.8 10 4.65 4.85a.5.5 0 0 1 0-.7Z"></path>
+					</svg>
+				</fluent-button>
+			</nav>
+		</div>
+	</body>
+</html>

--- a/tests/Core/Components/Paginator/FluentPaginatorTests.razor
+++ b/tests/Core/Components/Paginator/FluentPaginatorTests.razor
@@ -58,7 +58,7 @@
 
         // Assert
         var summaryText = cut.Find(".summary").TextContent.Trim();
-        var expected = $"1 {IFluentLocalizer.GetDefault("Paginator_SummaryItem")}";
+        var expected = $"{IFluentLocalizer.GetDefault("Paginator_SummaryItem", 1)}";
 
         Assert.Equal(expected, summaryText);
     }
@@ -75,7 +75,7 @@
 
         // Assert
         var summaryText = cut.Find(".summary").TextContent.Trim();
-        var expected = $"2 {IFluentLocalizer.GetDefault("Paginator_SummaryItems")}";
+        var expected = $"{IFluentLocalizer.GetDefault("Paginator_SummaryItems", 2)}";
 
         Assert.Equal(expected, summaryText);
     }

--- a/tests/Core/Components/Paginator/FluentPaginatorTests.razor
+++ b/tests/Core/Components/Paginator/FluentPaginatorTests.razor
@@ -30,7 +30,7 @@
     }
 
     [Fact]
-    public async Task FluentPaginator_Renders_SummaryItemResource_ForNoItems()
+    public async Task FluentPaginator_Renders_SummaryNoItemsResource_ForNoItems()
     {
         // Arrange
         var state = new PaginationState();

--- a/tests/Core/Components/Paginator/FluentPaginatorTests.razor
+++ b/tests/Core/Components/Paginator/FluentPaginatorTests.razor
@@ -30,6 +30,57 @@
     }
 
     [Fact]
+    public async Task FluentPaginator_Renders_SummaryItemResource_ForNoItems()
+    {
+        // Arrange
+        var state = new PaginationState();
+        await state.SetTotalItemCountAsync(0);
+
+        // Act
+        var cut = Render(@<FluentPaginator State="@state" />);
+
+        // Assert
+        var summaryText = cut.Find(".summary").TextContent.Trim();
+        var expected = $"{IFluentLocalizer.GetDefault("Paginator_SummaryNoItems")}";
+
+        Assert.Equal(expected, summaryText);
+    }
+
+    [Fact]
+    public async Task FluentPaginator_Renders_SummaryItemResource_ForSingleItem()
+    {
+        // Arrange
+        var state = new PaginationState();
+        await state.SetTotalItemCountAsync(1);
+
+        // Act
+        var cut = Render(@<FluentPaginator State="@state" />);
+
+        // Assert
+        var summaryText = cut.Find(".summary").TextContent.Trim();
+        var expected = $"1 {IFluentLocalizer.GetDefault("Paginator_SummaryItem")}";
+
+        Assert.Equal(expected, summaryText);
+    }
+
+    [Fact]
+    public async Task FluentPaginator_Renders_SummaryItemsResource_ForMultipleItems()
+    {
+        // Arrange
+        var state = new PaginationState();
+        await state.SetTotalItemCountAsync(2);
+
+        // Act
+        var cut = Render(@<FluentPaginator State="@state" />);
+
+        // Assert
+        var summaryText = cut.Find(".summary").TextContent.Trim();
+        var expected = $"2 {IFluentLocalizer.GetDefault("Paginator_SummaryItems")}";
+
+        Assert.Equal(expected, summaryText);
+    }
+
+    [Fact]
     public async Task FluentPaginator_SetItemsPerPage()
     {
         // Arrange
@@ -60,7 +111,7 @@
         var cut = Render(@<FluentPaginator State="@state" />);
 
         // Assert
-        
+
         Assert.NotNull(cut.Find(".fluent-paginator"));
         Assert.NotNull(cut.Find(".summary"));
         Assert.NotNull(cut.Find(".paginator-nav"));


### PR DESCRIPTION
This pull request enhances the `FluentPaginator` component by improving its localization support for summary item text and updating related documentation and tests. The changes ensure that the paginator's summary correctly adapts to different item counts (none, one, or many) and that all summary strings are localizable.

Fix #4658

**Localization improvements:**

* Added support for localizing summary strings in the paginator (e.g., "No items", "item", "items") by updating `FluentPaginator.razor` to use localized resources based on the item count.
* Introduced new localization resource entries (`Paginator_SummaryItem`, `Paginator_SummaryItems`, `Paginator_SummaryNoItems`) in `LanguageResource.resx`.
* Updated the documentation to describe how to localize paginator UI strings and listed all relevant keys.

**Testing updates:**

* Added new tests in `FluentPaginatorTests.razor` to verify correct summary text rendering for zero, one, and multiple items, ensuring localization works as intended.
* Updated verified test output files to reflect the new summary rendering and HTML structure. [[1]](diffhunk://#diff-9e7938dcbc5c3b1013541934513d2b7966da756c1413f19c0835c49bbe45af92L1-R33) [[2]](diffhunk://#diff-bbf81322e6376a63ac1b7e651145932b948d9804e3398cb171bf1e57e08813fdL1-R35) [[3]](diffhunk://#diff-c5a55890a59f5607ea47782ad3947217d0e29e54df19e9f1e16d3108a6806114L1-R33)