### PR TITLE
[MessageBar] Fix NullReferenceException and thread safety in MessageService

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -372,7 +372,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
 
     // Returns Loading if set (controlled). If not controlled,
     // we assume the grid is loading until the next data load completes
-    internal bool EffectiveLoadingValue => Loading ?? ItemsProvider is not null;
+    internal bool EffectiveLoadingValue => Loading ?? (ItemsProvider is not null);
 
     private ElementReference? _gridReference;
     //private DotNetObjectReference<Type>? _dotNetObjectReference;

--- a/src/Core/Components/MessageBar/Services/MessageService.cs
+++ b/src/Core/Components/MessageBar/Services/MessageService.cs
@@ -66,9 +66,12 @@ public class MessageService : IMessageService, IDisposable
         MessageLock.EnterReadLock();
         try
         {
-            IEnumerable<Message> messages = string.IsNullOrEmpty(section)
-                       ? MessageList
-                       : MessageList.Where(x => x.Section == section);
+            IEnumerable<Message> messages = MessageList;
+
+            if (!string.IsNullOrEmpty(section))
+            {
+                messages = messages.Where(x => x.Section == section);
+            }
 
             if (count > 0)
             {

--- a/src/Core/Components/MessageBar/Services/MessageService.cs
+++ b/src/Core/Components/MessageBar/Services/MessageService.cs
@@ -46,7 +46,7 @@ public class MessageService : IMessageService, IDisposable
             MessageLock.EnterReadLock();
             try
             {
-                return MessageList;
+                return MessageList.ToList();
             }
             finally
             {
@@ -66,11 +66,16 @@ public class MessageService : IMessageService, IDisposable
         MessageLock.EnterReadLock();
         try
         {
-            var messages = string.IsNullOrEmpty(section)
+            IEnumerable<Message> messages = string.IsNullOrEmpty(section)
                        ? MessageList
                        : MessageList.Where(x => x.Section == section);
 
-            return count > 0 ? messages.Take(count) : messages;
+            if (count > 0)
+            {
+                messages = messages.Take(count);
+            }
+
+            return messages.ToList();
         }
         finally
         {
@@ -263,7 +268,10 @@ public class MessageService : IMessageService, IDisposable
             MessageLock.ExitWriteLock();
         }
 
-        await OnMessageItemsUpdatedAsync!.Invoke();
+        if (OnMessageItemsUpdatedAsync is { } handler)
+        {
+            await handler.Invoke();
+        }
 
         return message;
     }


### PR DESCRIPTION
## Summary

Fix #4674

### NullReferenceException in `ShowMessageBarAsync`

`ShowMessageBarAsync` called `await OnMessageItemsUpdatedAsync!.Invoke()` without a null check. If `ShowMessageBarAsync` is called before `FluentMessageBarProvider.OnInitialized` subscribes to the event, this throws a `NullReferenceException`. The delegate is now captured in a local variable before invoking for thread safety:

```csharp
if (OnMessageItemsUpdatedAsync is { } handler)
{
    await handler.Invoke();
}
```

### Thread safety of `AllMessages` and `MessagesToShow`

Both properties/methods acquired a read lock but returned the live `MessageList` reference. The lock was released before the caller could enumerate, so concurrent writes (e.g. adding a message) could modify the collection during enumeration, causing `InvalidOperationException`.

Both now return a snapshot copy via `.ToList()` while still holding the read lock.