### PR TITLE
[DataGrid] Skip debounce delay on first provider call when using virtualize

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -372,7 +372,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
 
     // Returns Loading if set (controlled). If not controlled,
     // we assume the grid is loading until the next data load completes
-    internal bool EffectiveLoadingValue => Loading ?? ItemsProvider is not null;
+    internal bool EffectiveLoadingValue => Loading ?? (ItemsProvider is not null);
 
     private ElementReference? _gridReference;
     //private DotNetObjectReference<Type>? _dotNetObjectReference;
@@ -423,6 +423,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
 
     private GridItemsProvider<TGridItem>? _lastAssignedItemsProvider;
     private CancellationTokenSource? _pendingDataLoadCancellationTokenSource;
+    private bool _isFirstVirtualizeProviderCall = true;
 
     private Exception? _lastError;
     private GridItemsProviderRequest<TGridItem>? _lastRequest;
@@ -865,9 +866,15 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         _lastRefreshedPaginationState = Pagination;
 
         // Debounce the requests. This eliminates a lot of redundant queries at the cost of slight lag after interactions.
-        // TODO: Consider making this configurable, or smarter (e.g., doesn't delay on first call in a batch, then the amount
-        // of delay increases if you rapidly issue repeated requests, such as when scrolling a long way)
-        await Task.Delay(100);
+        // Skip the delay on the first call to avoid unnecessary lag on initial load.
+        if (_isFirstVirtualizeProviderCall)
+        {
+            _isFirstVirtualizeProviderCall = false;
+        }
+        else
+        {
+            await Task.Delay(100);
+        }
 
         if (request.CancellationToken.IsCancellationRequested)
         {


### PR DESCRIPTION
# Fix FluentDataGrid initial load performance

Fixes #4676

## Problem

`ProvideVirtualizedItemsAsync` unconditionally calls `await Task.Delay(100)` before every request, including the very first one on page load. This introduces an artificial 100ms delay before grid rows are displayed, even when the `ItemsProvider` callback is synchronous.

## Solution

Added a `_isFirstVirtualizeProviderCall` boolean field that skips the debounce delay on the first call. Subsequent calls (e.g., during scrolling) continue to be debounced as before.

Also fixed a pre-existing IDE0048 build error (missing parentheses for clarity) on the same file.

## Changes

- `FluentDataGrid.razor.cs`: Skip `Task.Delay(100)` on the first `ProvideVirtualizedItemsAsync` call
- `FluentDataGrid.razor.cs`: Add parentheses to `EffectiveLoadingValue` expression to fix IDE0048