### PR TITLE
Rollup PRs #4677 and and #4678

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGrid.razor.cs
@@ -429,6 +429,7 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
 
     private GridItemsProvider<TGridItem>? _lastAssignedItemsProvider;
     private CancellationTokenSource? _pendingDataLoadCancellationTokenSource;
+    private bool _isFirstVirtualizeProviderCall = true;
 
     private Exception? _lastError;
     private GridItemsProviderRequest<TGridItem>? _lastRequest;
@@ -889,9 +890,15 @@ public partial class FluentDataGrid<TGridItem> : FluentComponentBase, IHandleEve
         _lastRefreshedPaginationState = Pagination;
 
         // Debounce the requests. This eliminates a lot of redundant queries at the cost of slight lag after interactions.
-        // TODO: Consider making this configurable, or smarter (e.g., doesn't delay on first call in a batch, then the amount
-        // of delay increases if you rapidly issue repeated requests, such as when scrolling a long way)
-        await Task.Delay(100);
+        // Skip the delay on the first call to avoid unnecessary lag on initial load.
+        if (_isFirstVirtualizeProviderCall)
+        {
+            _isFirstVirtualizeProviderCall = false;
+        }
+        else
+        {
+            await Task.Delay(100);
+        }
 
         if (request.CancellationToken.IsCancellationRequested)
         {

--- a/src/Core/Components/MessageBar/Services/MessageService.cs
+++ b/src/Core/Components/MessageBar/Services/MessageService.cs
@@ -46,7 +46,7 @@ public class MessageService : IMessageService, IDisposable
             MessageLock.EnterReadLock();
             try
             {
-                return MessageList;
+                return MessageList.ToList();
             }
             finally
             {
@@ -66,11 +66,19 @@ public class MessageService : IMessageService, IDisposable
         MessageLock.EnterReadLock();
         try
         {
-            var messages = string.IsNullOrEmpty(section)
-                       ? MessageList
-                       : MessageList.Where(x => x.Section == section);
+            IEnumerable<Message> messages = MessageList;
 
-            return count > 0 ? messages.Take(count) : messages;
+            if (!string.IsNullOrEmpty(section))
+            {
+                messages = messages.Where(x => x.Section == section);
+            }
+
+            if (count > 0)
+            {
+                messages = messages.Take(count);
+            }
+
+            return messages.ToList();
         }
         finally
         {
@@ -128,7 +136,7 @@ public class MessageService : IMessageService, IDisposable
     /// <summary>
     /// Show a message based on the provided parameters in a message bar.
     /// </summary>
-    /// <param name="title"> Main info. 
+    /// <param name="title"> Main info.
     /// Using MarkupString can introduce XSS vulnerabilities because it renders unencoded HTML.
     /// Only use it with fully trusted, sanitized content.</param>
     /// <param name="intent">Intent of the message</param>
@@ -223,7 +231,7 @@ public class MessageService : IMessageService, IDisposable
     /// <summary>
     /// Show a message based on the provided parameters in a message bar.
     /// </summary>
-    /// <param name="title"> Main info. 
+    /// <param name="title"> Main info.
     /// Using MarkupString can introduce XSS vulnerabilities because it renders unencoded HTML.
     /// Only use it with fully trusted, sanitized content.</param>
     /// <param name="intent">Intent of the message</param>
@@ -263,7 +271,10 @@ public class MessageService : IMessageService, IDisposable
             MessageLock.ExitWriteLock();
         }
 
-        await OnMessageItemsUpdatedAsync!.Invoke();
+        if (OnMessageItemsUpdatedAsync is { } handler)
+        {
+            await handler.Invoke();
+        }
 
         return message;
     }
@@ -326,10 +337,7 @@ public class MessageService : IMessageService, IDisposable
     /// <summary />
     public void Dispose()
     {
-        if (_navigationManager != null)
-        {
-            _navigationManager.LocationChanged -= NavigationManager_LocationChanged;
-        }
+        _navigationManager?.LocationChanged -= NavigationManager_LocationChanged;
 
         RemoveMessageItems(section: null);
     }


### PR DESCRIPTION
Original PRs were created by @JamesNK. Thanks!


## Summary

Fix #4674

### NullReferenceException in `ShowMessageBarAsync`

`ShowMessageBarAsync` called `await OnMessageItemsUpdatedAsync!.Invoke()` without a null check. If `ShowMessageBarAsync` is called before `FluentMessageBarProvider.OnInitialized` subscribes to the event, this throws a `NullReferenceException`. The delegate is now captured in a local variable before invoking for thread safety:

```csharp
if (OnMessageItemsUpdatedAsync is { } handler)
{
    await handler.Invoke();
}
```

### Thread safety of `AllMessages` and `MessagesToShow`

Both properties/methods acquired a read lock but returned the live `MessageList` reference. The lock was released before the caller could enumerate, so concurrent writes (e.g. adding a message) could modify the collection during enumeration, causing `InvalidOperationException`.

Both now return a snapshot copy via `.ToList()` while still holding the read lock.

# Fix FluentDataGrid initial load performance

Fixes #4676

## Problem

`ProvideVirtualizedItemsAsync` unconditionally calls `await Task.Delay(100)` before every request, including the very first one on page load. This introduces an artificial 100ms delay before grid rows are displayed, even when the `ItemsProvider` callback is synchronous.

## Solution

Added a `_isFirstVirtualizeProviderCall` boolean field that skips the debounce delay on the first call. Subsequent calls (e.g., during scrolling) continue to be debounced as before.

Also fixed a pre-existing IDE0048 build error (missing parentheses for clarity) on the same file.

## Changes

- `FluentDataGrid.razor.cs`: Skip `Task.Delay(100)` on the first `ProvideVirtualizedItemsAsync` call
- `FluentDataGrid.razor.cs`: Add parentheses to `EffectiveLoadingValue` expression to fix IDE0048