### PR TITLE
[dev-v5] Update moduleResolution in tsconfig.json to use Bundler

### DIFF
--- a/src/Core.Scripts/tsconfig.json
+++ b/src/Core.Scripts/tsconfig.json
@@ -7,7 +7,7 @@
 
     /* Modules */
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "lib": [ "ESNext", "DOM" ],
     /* Emit */
     "sourceMap": true, /* Create source map files for emitted JavaScript files. */


### PR DESCRIPTION
# [dev-v5] Update moduleResolution in tsconfig.json to use Bundler

Fix this TypeScript warning:
> Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.

The warning is because `"moduleResolution": "Node"` resolves to the legacy `node10` algorithm, which is deprecated in modern TypeScript. Since this project uses esbuild as a bundler, change it to `"Bundler"`