### PR TITLE
[dev-v5] Example TextInput with button

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputPrefixSuffix.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/TextInput/Examples/TextInputPrefixSuffix.razor
@@ -1,5 +1,8 @@
-﻿<FluentStack HorizontalGap="20px">
-    <FluentTextInput Label="Company Url" @bind-Value="@Sometext1">
+﻿@inject IJSRuntime JSRuntime
+@inject IToastService ToastService
+
+<FluentStack HorizontalGap="20px" Wrap="true">
+    <FluentTextInput Label="Company Url" @bind-Value="@Domain">
         <StartTemplate>
             <fluent-label>https://</fluent-label>
         </StartTemplate>
@@ -8,14 +11,36 @@
         </EndTemplate>
     </FluentTextInput>
 
-    <FluentTextInput Label="Email" TextInputType="TextInputType.Email" @bind-Value="@Sometext2" Style="width: 300px;">
+    <FluentTextInput Label="Email" TextInputType="TextInputType.Email" @bind-Value="@EmailAddress" Style="width: 300px;">
         <StartTemplate>
             <FluentIcon Value="@(new Icons.Regular.Size20.Mail())" />
         </StartTemplate>
     </FluentTextInput>
+
+    <FluentTextInput Label="Email" TextInputType="TextInputType.Email" @bind-Value="@EmailAddress" Style="width: 300px;">
+        <EndTemplate>
+            <FluentButton Appearance="ButtonAppearance.Transparent"
+                        Size="ButtonSize.Small"
+                        Tooltip="Copy email address"
+                        IconOnly="true"
+                        OnClick="@CopyToClipboardAsync"
+                        IconStart="@(new Icons.Regular.Size16.Copy())" />
+        </EndTemplate>
+    </FluentTextInput>
+
 </FluentStack>
 
 @code {
-    private string Sometext1 = "microsoft";
-    private string Sometext2 = "fluentui-blazor@microsoft.com";
+    string Domain = "microsoft";
+    string EmailAddress = "fluentui-blazor@microsoft.com";
+
+    async Task CopyToClipboardAsync()
+    {
+        await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", EmailAddress);
+        
+        await ToastService.ShowToastAsync(options => {
+            options.Intent = ToastIntent.Success;
+            options.Title = "Email address copied to clipboard!";
+        });
+    }
 }


### PR DESCRIPTION
# [dev-v5] Example TextInput with button

Enhance the **TextInputPrefixSuffix** example by adding clipboard copy functionality for the email input. This change improves user experience by allowing users to easily copy the email address with a button click. 

_Additionally, update the bindings for the input fields to reflect more meaningful variable names._

![peek_1](https://github.com/user-attachments/assets/db7a0f56-5574-44f5-a21a-700aa67d48da)
