### PR TITLE
[dev-v5][DataGrid] Use the TextInput EndTemplate to show buttons

### DIFF
--- a/src/Core/Components/DataGrid/Columns/ColumnResizeOptions.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnResizeOptions.razor
@@ -17,7 +17,7 @@ else
     <FluentStack Orientation="Orientation.Horizontal" HorizontalAlignment="HorizontalAlignment.End" VerticalAlignment="VerticalAlignment.Bottom" HorizontalGap="4">
         <FluentTextInput Id="width"
                          @bind-Value="@_width"
-                         Style="width: 100%;    "
+                         Style="width: 100%;"
                          InputMode="TextInputMode.Numeric"
                          Immediate="true"
                          ImmediateDelay="200"

--- a/src/Core/Components/DataGrid/Columns/ColumnResizeOptions.razor
+++ b/src/Core/Components/DataGrid/Columns/ColumnResizeOptions.razor
@@ -14,21 +14,22 @@
 }
 else
 {
-    <FluentStack Orientation="Orientation.Horizontal" HorizontalAlignment="HorizontalAlignment.End" VerticalAlignment="VerticalAlignment.Center" HorizontalGap="4">
+    <FluentStack Orientation="Orientation.Horizontal" HorizontalAlignment="HorizontalAlignment.End" VerticalAlignment="VerticalAlignment.Bottom" HorizontalGap="4">
         <FluentTextInput Id="width"
                          @bind-Value="@_width"
-                         Style="width: 100%;"
+                         Style="width: 100%;    "
                          InputMode="TextInputMode.Numeric"
                          Immediate="true"
                          ImmediateDelay="200"
                          Label="@Localizer[Localization.LanguageResource.DataGrid_ResizeExact]"
                          AutoComplete="off"
                          Autofocus="true"
-                         @onkeydown="@HandleColumnWidthKeyDownAsync" />
-        <div style="display: flex; flex-direction: row; gap: 2px; margin-top: 20px;">
-            <FluentButton OnClick="@HandleColumnWidthAsync" IconStart="@(new CoreIcons.Regular.Size20.Checkmark())" Appearance="@ButtonAppearance.Primary" aria-label="@Localizer[Localization.LanguageResource.DataGrid_ResizeSubmit]" />
-            <FluentButton OnClick="@HandleResetAsync" IconStart="@(new CoreIcons.Regular.Size20.ArrowReset())" aria-label="@Localizer[Localization.LanguageResource.DataGrid_ResizeReset]" />
-        </div>
+                         @onkeydown="@HandleColumnWidthKeyDownAsync">
+            <EndTemplate>
+                <FluentButton Size="ButtonSize.Small" OnClick="@HandleColumnWidthAsync" IconStart="@(new CoreIcons.Regular.Size20.Checkmark())" Appearance="@ButtonAppearance.Subtle" aria-label="@Localizer[Localization.LanguageResource.DataGrid_ResizeSubmit]" />
+                <FluentButton Size="ButtonSize.Small" OnClick="@HandleResetAsync" IconStart="@(new CoreIcons.Regular.Size20.ArrowReset())" Appearance="@ButtonAppearance.Subtle" aria-label="@Localizer[Localization.LanguageResource.DataGrid_ResizeReset]" />
+            </EndTemplate>
+        </FluentTextInput>
     </FluentStack>
 }
 


### PR DESCRIPTION
Use the EndTemplate to show apply/reset buttons in the column resize options.

**Before**
<img width="276" height="145" alt="image" src="https://github.com/user-attachments/assets/50a71948-9bc3-4857-b3fd-a743b721c3de" />


**After**
<img width="260" height="98" alt="image" src="https://github.com/user-attachments/assets/ee53fbdd-f12c-4ad6-8520-07c1fe6a4cf1" />
