### PR TITLE
[dev-v5] Update FluentDialog to display a scrollbar

### DIFF
--- a/src/Core/Components/Dialog/FluentDialog.razor.css
+++ b/src/Core/Components/Dialog/FluentDialog.razor.css
@@ -1,19 +1,28 @@
+fluent-dialog[fuib]::part(dialog) {
+  width: 600px;
+  max-width: min(600px, 100vw);
+}
+
 fluent-dialog[fuib][size="small"]::part(dialog) {
   width: 320px;
-  max-width: 320px;
+  max-width: min(320px, 100vw);
 }
 
 fluent-dialog[fuib][size="medium"]::part(dialog) {
   width: 592px;
-  max-width: 592px;
+  max-width: min(592px, 100vw);
 }
 
 fluent-dialog[fuib][size="large"]::part(dialog) {
   width: 940px;
-  max-width: 940px;
+  max-width: min(940px, 100vw);
 }
 
 fluent-dialog[fuib][size="full"]::part(dialog) {
   width: 100%;
   max-width: calc(-48px + 100vw);
+}
+
+fluent-dialog-body::part(content) { 
+  overflow: auto;
 }


### PR DESCRIPTION
# [dev-v5] Update FluentDialog to display a scrollbar

Update **FluentDialog** CSS to display a scrollbar when the content is too large.

https://github.com/user-attachments/assets/30cdd141-d65b-4f96-82ed-37920f7ec1cc

