### PR TITLE
[dev-v5][DataGrid] Remove extra px from pinned columns

### DIFF
--- a/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
+++ b/src/Core/Components/DataGrid/FluentDataGridCell.razor.cs
@@ -50,8 +50,8 @@ public partial class FluentDataGridCell<TGridItem> : FluentComponentBase
         .AddStyle("height", "100%", Grid.MultiLine)
         .AddStyle("min-height", "40px", Owner.RowType != DataGridRowType.Default)
         .AddStyle("position", "sticky", Column != null && Column.Pin != DataGridColumnPin.None)
-        .AddStyle("inset-inline-start", $"{Column?.PinOffset}px", Column != null && Column.Pin == DataGridColumnPin.Start)
-        .AddStyle("inset-inline-end", $"{Column?.PinOffset}px", Column != null && Column.Pin == DataGridColumnPin.End)
+        .AddStyle("inset-inline-start", $"{Column?.PinOffset}", Column != null && Column.Pin == DataGridColumnPin.Start)
+        .AddStyle("inset-inline-end", $"{Column?.PinOffset}", Column != null && Column.Pin == DataGridColumnPin.End)
         .AddStyle("z-index", "1", Column != null && Column.Pin != DataGridColumnPin.None && CellType == DataGridCellType.Default)
         .AddStyle(Owner.Style)
         .Build();


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR removes the extra `px` from `FluentDataGridCell` for pinned columns. Otherwise this will result in an invalid CSS value like this.

<img width="257" height="139" alt="grafik" src="https://github.com/user-attachments/assets/ed4380f8-7409-40e8-aed7-5c8fe3264039" />


### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
