### PR TITLE
Add VS Code sandboxing configuration details to installation and security documentation

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Installation.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Installation.md
@@ -141,7 +141,7 @@ Because the Fluent UI Blazor MCP Server requires no file writes and no network a
 This applies equally to the `dnx`-based configuration — just add `"sandboxEnabled": true` to the server entry.
 
 > [!NOTE]
-> When sandboxing is enabled, VS Code auto-approves tool confirmations because the server runs in a controlled environment. This setting has no effect on Windows.
+> When sandboxing is enabled, VS Code may handle tool confirmations differently because the server runs in a controlled environment. Check the current VS Code documentation for the exact behavior in your version. This setting has no effect on Windows.
 
 For advanced sandbox rules (restricting specific paths or domains), see the [VS Code MCP Sandbox Configuration](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration#_sandbox-configuration) reference.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Installation.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Installation.md
@@ -121,6 +121,30 @@ Or in the configuration:
 }
 ```
 
+## Enable Sandboxing in VS Code (Optional)
+
+VS Code supports native **sandboxing** for stdio MCP servers on **macOS and Linux**. Sandboxed servers can only access the file system paths and network domains that you explicitly permit.
+
+Because the Fluent UI Blazor MCP Server requires no file writes and no network access, you can enable the most restrictive sandbox with a single property:
+
+```json
+{
+    "servers": {
+        "fluent-ui-blazor": {
+            "command": "fluentui-mcp",
+            "sandboxEnabled": true
+        }
+    }
+}
+```
+
+This applies equally to the `dnx`-based configuration — just add `"sandboxEnabled": true` to the server entry.
+
+> [!NOTE]
+> When sandboxing is enabled, VS Code auto-approves tool confirmations because the server runs in a controlled environment. This setting has no effect on Windows.
+
+For advanced sandbox rules (restricting specific paths or domains), see the [VS Code MCP Sandbox Configuration](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration#_sandbox-configuration) reference.
+
 ## NuGet Package
 
 For all available versions and additional installation methods, visit the official NuGet page:

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Security.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Security.md
@@ -82,7 +82,7 @@ Because the Fluent UI Blazor MCP Server requires no network access and no file s
 This configuration grants zero file system write permissions and zero network access — matching the server's actual capability profile.
 
 > [!NOTE]
-> When `sandboxEnabled` is `true`, VS Code automatically approves tool confirmations because the server runs in a controlled environment.
+> When `sandboxEnabled` is `true`, VS Code may handle tool confirmations differently because the server runs in a controlled environment. The exact behavior can depend on the VS Code version and configuration, so verify the current behavior against the official VS Code documentation and your local setup.
 
 For the full list of `sandbox` properties (`filesystem.allowWrite`, `filesystem.denyRead`, `network.allowedDomains`, etc.), see the [VS Code MCP Sandbox Configuration](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration#_sandbox-configuration) reference.
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Security.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Mcp/Security.md
@@ -60,6 +60,32 @@ The MCP server runs as a **child process** of your IDE with:
 - Sandboxed by the IDE runtime
 - Cannot access resources outside its working directory
 
+### VSCode Native Sandboxing
+
+VS Code provides a built-in **sandbox layer** for locally-running `stdio` MCP servers that restricts file system and network access at the OS level. This is available on **macOS and Linux** and provides an additional defense-in-depth control on top of process isolation.
+
+When sandboxing is enabled, the MCP server can only access the file system paths and network domains explicitly listed in the `sandbox` configuration — all other access is denied by the OS.
+
+Because the Fluent UI Blazor MCP Server requires no network access and no file system writes, it is an ideal candidate for the most restrictive sandbox policy. A minimal configuration is:
+
+```json
+{
+    "servers": {
+        "fluent-ui-blazor": {
+            "command": "fluentui-mcp",
+            "sandboxEnabled": true
+        }
+    }
+}
+```
+
+This configuration grants zero file system write permissions and zero network access — matching the server's actual capability profile.
+
+> [!NOTE]
+> When `sandboxEnabled` is `true`, VS Code automatically approves tool confirmations because the server runs in a controlled environment.
+
+For the full list of `sandbox` properties (`filesystem.allowWrite`, `filesystem.denyRead`, `network.allowedDomains`, etc.), see the [VS Code MCP Sandbox Configuration](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration#_sandbox-configuration) reference.
+
 ## Permission Model
 
 ### What the MCP Server CAN Do
@@ -299,7 +325,7 @@ Content served by MCP:
 
 ### Q: How do we verify the integrity of the MCP server?
 
-**A:** 
+**A:**
 1. Verify NuGet package signature
 2. Review open-source code on GitHub
 3. Build from source for additional assurance

--- a/src/Tools/McpServer/README.md
+++ b/src/Tools/McpServer/README.md
@@ -376,7 +376,7 @@ The Fluent UI Blazor MCP Server is designed with security as a priority:
 - ❌ Access environment variables or credentials
 - ❌ Launch other processes
 
-### VSCode Sandbox Configuration
+### VS Code Sandbox Configuration
 
 VS Code supports native **sandboxing** for locally-running `stdio` MCP servers (available on **macOS and Linux only**). Sandboxed servers can only access the file system paths and network domains that you explicitly permit — all other access is blocked.
 

--- a/src/Tools/McpServer/README.md
+++ b/src/Tools/McpServer/README.md
@@ -376,6 +376,33 @@ The Fluent UI Blazor MCP Server is designed with security as a priority:
 - ❌ Access environment variables or credentials
 - ❌ Launch other processes
 
+### VSCode Sandbox Configuration
+
+VS Code supports native **sandboxing** for locally-running `stdio` MCP servers (available on **macOS and Linux only**). Sandboxed servers can only access the file system paths and network domains that you explicitly permit — all other access is blocked.
+
+The Fluent UI Blazor MCP Server is an ideal candidate for sandboxing because it:
+- Requires **no network access** — documentation is embedded in the binary
+- Requires **no file system writes**
+- Reads only its own embedded resources, not your project files
+
+Enable sandboxing by adding `"sandboxEnabled": true` to your server entry in `.vscode/mcp.json`:
+
+```json
+{
+    "servers": {
+        "fluent-ui-blazor": {
+            "command": "fluentui-mcp",
+            "sandboxEnabled": true
+        }
+    }
+}
+```
+
+> [!NOTE]
+> When sandboxing is enabled, VS Code automatically approves tool confirmations because the server runs in a controlled environment.
+
+For a full reference of sandbox properties (`filesystem.allowWrite`, `filesystem.denyRead`, `network.allowedDomains`, and more), see the [VS Code MCP Sandbox Configuration](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration#_sandbox-configuration) documentation.
+
 ### For SecOps Teams
 
 For comprehensive security information including:

--- a/src/Tools/McpServer/README.md
+++ b/src/Tools/McpServer/README.md
@@ -399,7 +399,7 @@ Enable sandboxing by adding `"sandboxEnabled": true` to your server entry in `.v
 ```
 
 > [!NOTE]
-> When sandboxing is enabled, VS Code automatically approves tool confirmations because the server runs in a controlled environment.
+> When sandboxing is enabled, tool confirmation behavior may differ because the server runs in a controlled environment. Refer to the VS Code MCP sandbox documentation below for the current behavior and configuration details.
 
 For a full reference of sandbox properties (`filesystem.allowWrite`, `filesystem.denyRead`, `network.allowedDomains`, and more), see the [VS Code MCP Sandbox Configuration](https://code.visualstudio.com/docs/copilot/reference/mcp-configuration#_sandbox-configuration) documentation.
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This pull request improves the documentation for the Fluent UI Blazor MCP Server by adding detailed guidance on enabling and configuring VS Code's native sandboxing feature for MCP servers. The updates clarify that sandboxing is supported on macOS and Linux, describe its security benefits, and provide example configurations for users to easily adopt the most restrictive and secure settings.

**Documentation updates on VS Code sandboxing:**

* Added a new section to `Installation.md` explaining how to enable VS Code's native sandboxing for the Fluent UI Blazor MCP Server, including example configuration and a note about its platform support and security implications.
* Expanded the `Security.md` documentation to describe VS Code's built-in sandbox layer, how it restricts file system and network access, and provided a minimal configuration example. Included a reference to advanced sandbox configuration options.
* Updated the MCP server's `README.md` to document the suitability of the Fluent UI Blazor MCP Server for sandboxing, instructions for enabling it, and a link to the full VS Code MCP sandbox configuration documentation.


## 👩‍💻 Reviewer Notes

Just improving docs about MCPs


## ✅ Checklist

### General

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.


