### PR TITLE
[dev-v5][Docs] Extend the DocApiGen and DocViewer projects

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Infrastructure/ServiceCollectionExtensions.cs
+++ b/examples/Demo/FluentUI.Demo.Client/Infrastructure/ServiceCollectionExtensions.cs
@@ -64,7 +64,10 @@ public static class ServiceCollectionExtensions
             options.PageTitle = "{0} - FluentUI Blazor Components";
             options.ComponentsAssembly = typeof(Client._Imports).Assembly;
             options.ResourcesAssembly = typeof(Client._Imports).Assembly;
-            options.ApiAssembly = typeof(Microsoft.FluentUI.AspNetCore.Components._Imports).Assembly;
+            options.ApiAssemblies =
+                [
+                    typeof(Microsoft.FluentUI.AspNetCore.Components._Imports).Assembly,
+                ];
             options.ApiCommentSummary = (data, component, member) =>
             {
                 if (member is null && (data is null || data?.Items?.Count <= 1))

--- a/examples/Tools/FluentUI.Demo.DocApiGen.IntegrationTests/FluentUIComponentsIntegrationTests.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen.IntegrationTests/FluentUIComponentsIntegrationTests.cs
@@ -2,13 +2,12 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
-using FluentUI.Demo.DocApiGen;
+using System.Reflection;
+using System.Text.Json;
 using FluentUI.Demo.DocApiGen.Abstractions;
 using FluentUI.Demo.DocApiGen.Formatters;
 using FluentUI.Demo.DocApiGen.Generators;
-using System.Reflection;
-using System.Text.Json;
-using Xunit;
+using FluentUI.Demo.DocApiGen.Models;
 
 namespace FluentUI.Demo.DocApiGen.IntegrationTests;
 
@@ -24,7 +23,9 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     private readonly FileInfo _xmlDocumentation;
     private readonly string _tempOutputDirectory;
     private readonly string _xmlPath;
+    private readonly DocumentationAssemblyLoadContext _assemblyLoadContext;
     private readonly Assembly _fluentUIAssembly;
+    private readonly IReadOnlyList<DocumentationInput> _documentationInputs;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FluentUIComponentsIntegrationTests"/> class.
@@ -44,22 +45,30 @@ public class FluentUIComponentsIntegrationTests : IDisposable
         }
 
         _xmlDocumentation = new FileInfo(_xmlPath);
+        _assemblyLoadContext = new DocumentationAssemblyLoadContext([GetAssemblyPath(projectRoot, Path.Combine("src", "Core"), "Microsoft.FluentUI.AspNetCore.Components.dll")]);
 
         // Load the FluentUI assembly dynamically
-        var fluentUIAssemblyPath = Path.Combine(projectRoot, "src", "Core", "bin", "Debug", NET_VERSION, "Microsoft.FluentUI.AspNetCore.Components.dll");
+        var fluentUIAssemblyPath = GetAssemblyPath(projectRoot, Path.Combine("src", "Core"), "Microsoft.FluentUI.AspNetCore.Components.dll");
 
-        if (!File.Exists(fluentUIAssemblyPath))
+        _fluentUIAssembly = _assemblyLoadContext.LoadFromAssemblyPath(fluentUIAssemblyPath);
+        _documentationInputs = [new DocumentationInput(_fluentUIAssembly, _xmlDocumentation)];
+    }
+
+    private static string GetAssemblyPath(string projectRoot, string relativeProjectDirectory, string assemblyFileName)
+    {
+        var debugPath = Path.Combine(projectRoot, relativeProjectDirectory, "bin", "Debug", NET_VERSION, assemblyFileName);
+        if (File.Exists(debugPath))
         {
-            // Try alternative path (Release build)
-            fluentUIAssemblyPath = Path.Combine(projectRoot, "src", "Core", "bin", "Release", NET_VERSION, "Microsoft.FluentUI.AspNetCore.Components.dll");
-
-            if (!File.Exists(fluentUIAssemblyPath))
-            {
-                throw new FileNotFoundException($"FluentUI assembly not found. Please build the Core project first. Looked for: {fluentUIAssemblyPath}");
-            }
+            return debugPath;
         }
 
-        _fluentUIAssembly = Assembly.LoadFrom(fluentUIAssemblyPath);
+        var releasePath = Path.Combine(projectRoot, relativeProjectDirectory, "bin", "Release", NET_VERSION, assemblyFileName);
+        if (File.Exists(releasePath))
+        {
+            return releasePath;
+        }
+
+        throw new FileNotFoundException($"Assembly not found. Please build the project first. Looked for: {releasePath}");
     }
 
     /// <summary>
@@ -72,7 +81,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
         // Look for solution file
         while (directory != null)
         {
-            var solutionFiles = directory.GetFiles("*.sln");
+            var solutionFiles = directory.GetFiles("*.slnx");
             if (solutionFiles.Length > 0)
             {
                 return directory.FullName;
@@ -108,7 +117,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_ShouldGenerateJsonSuccessfully()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: true);
 
         // Act
@@ -125,7 +134,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_ShouldGenerateCSharpSuccessfully()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateCSharpFormatter();
 
         // Act
@@ -143,7 +152,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_JsonOutput_ShouldContainFluentUIComponents()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: true);
 
         // Act
@@ -158,7 +167,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_CSharpOutput_ShouldContainFluentUIComponents()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateCSharpFormatter();
 
         // Act
@@ -173,7 +182,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_JsonOutput_ShouldBeValidJson()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: true);
 
         // Act
@@ -188,7 +197,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_SaveToFile_JsonShouldSucceed()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: true);
         var outputPath = Path.Combine(_tempOutputDirectory, "fluentui_summary.json");
 
@@ -211,7 +220,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_SaveToFile_CSharpShouldSucceed()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateCSharpFormatter();
         var outputPath = Path.Combine(_tempOutputDirectory, "fluentui_summary.cs");
 
@@ -230,7 +239,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_LargeScale_ShouldCompleteWithoutErrors()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var jsonFormatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: true);
         var csharpFormatter = OutputFormatterFactory.CreateCSharpFormatter();
 
@@ -253,7 +262,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_OutputSize_ShouldBeReasonable()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var jsonFormatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: true);
         var csharpFormatter = OutputFormatterFactory.CreateCSharpFormatter();
 
@@ -273,7 +282,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_JsonMetadata_ShouldBePresent()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: true);
 
         // Act
@@ -296,7 +305,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_CompactFormat_ShouldGenerateCorrectStructure()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: true);
 
         // Act
@@ -315,7 +324,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_CompactFormat_ShouldBeValidJson()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: true);
 
         // Act
@@ -330,7 +339,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_CompactFormat_SaveToFile_ShouldSucceed()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: true);
         var outputPath = Path.Combine(_tempOutputDirectory, "fluentui_compact.json");
 
@@ -349,6 +358,41 @@ public class FluentUIComponentsIntegrationTests : IDisposable
         Assert.Null(exception);
     }
 
+    [Fact]
+    public void AllGenerator_WithMultipleDocumentationInputs_ShouldIncludeChartsAssemblyTypes()
+    {
+        // Arrange
+        var projectRoot = GetProjectRootDirectory();
+        var chartsAssemblyPath = Path.Combine(projectRoot, "src", "Charts", "bin", "Debug", NET_VERSION, "Microsoft.FluentUI.AspNetCore.Components.Charts.dll");
+
+        if (!File.Exists(chartsAssemblyPath))
+        {
+            chartsAssemblyPath = Path.Combine(projectRoot, "src", "Charts", "bin", "Release", NET_VERSION, "Microsoft.FluentUI.AspNetCore.Components.Charts.dll");
+        }
+
+        var chartsXmlPath = Path.Combine(projectRoot, "examples", "Tools", "FluentUI.Demo.DocApiGen", "Microsoft.FluentUI.AspNetCore.Components.Charts.xml");
+
+        if (!File.Exists(chartsAssemblyPath) || !File.Exists(chartsXmlPath))
+        {
+            return;
+        }
+
+        var inputs = new List<DocumentationInput>(_documentationInputs)
+        {
+            new(new DocumentationAssemblyLoadContext([chartsAssemblyPath]).LoadFromAssemblyPath(chartsAssemblyPath), new FileInfo(chartsXmlPath))
+        };
+
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.All, inputs);
+        var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: false);
+
+        // Act
+        var json = generator.Generate(formatter);
+
+        // Assert
+        Assert.Contains("FluentDonutChart", json);
+        Assert.Contains("FluentHorizontalBarChart", json);
+    }
+
     #endregion
 
     #region Summary Mode Tests - Structured Format (Extended)
@@ -357,7 +401,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void SummaryGenerator_StructuredFormat_ShouldContainMetadata()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateSummaryGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.Summary, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: false);
 
         // Act
@@ -381,7 +425,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void AllGenerator_ShouldGenerateJsonSuccessfully()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateAllGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.All, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: false);
 
         // Act
@@ -398,7 +442,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void AllGenerator_ShouldNotSupportCSharpFormat()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateAllGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.All, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateCSharpFormatter();
 
         // Act & Assert
@@ -410,7 +454,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void AllGenerator_JsonOutput_ShouldContainComponents()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateAllGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.All, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: false);
 
         // Act
@@ -427,7 +471,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
     public void AllGenerator_SaveToFile_ShouldSucceed()
     {
         // Arrange
-        var generator = DocumentationGeneratorFactory.CreateAllGenerator(_fluentUIAssembly, _xmlDocumentation);
+        var generator = DocumentationGeneratorFactory.Create(GenerationMode.All, _documentationInputs);
         var formatter = OutputFormatterFactory.CreateJsonFormatter(useCompactFormat: false);
         var outputPath = Path.Combine(_tempOutputDirectory, "fluentui_all.json");
 
@@ -478,7 +522,7 @@ public class FluentUIComponentsIntegrationTests : IDisposable
             return null;
         }
 
-        var mcpAssembly = Assembly.LoadFrom(mcpAssemblyPath);
+        var mcpAssembly = new DocumentationAssemblyLoadContext([mcpAssemblyPath]).LoadFromAssemblyPath(mcpAssemblyPath);
         var mcpXml = new FileInfo(mcpXmlPath);
 
         return (mcpAssembly, mcpXml);

--- a/examples/Tools/FluentUI.Demo.DocApiGen.Tests/Models/IconEmoji/IconEmojiTests.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen.Tests/Models/IconEmoji/IconEmojiTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using FluentUI.Demo.DocApiGen.Abstractions;
 using FluentUI.Demo.DocApiGen.Formatters;
 using FluentUI.Demo.DocApiGen.Generators;
+using FluentUI.Demo.DocApiGen.Models;
 using Xunit;
 
 namespace FluentUI.Demo.DocApiGen.Tests.Models.IconEmoji;
@@ -18,6 +19,7 @@ public class IconEmojiTests
 {
     private readonly Assembly _testAssembly;
     private readonly FileInfo _testXmlFile;
+    private readonly IReadOnlyList<DocumentationInput> _testInputs;
 
     public IconEmojiTests()
     {
@@ -29,13 +31,14 @@ public class IconEmojiTests
         var tempPath = Path.Combine(Path.GetTempPath(), "test.xml");
         File.WriteAllText(tempPath, "<?xml version=\"1.0\"?><doc></doc>");
         _testXmlFile = new FileInfo(tempPath);
+        _testInputs = [new DocumentationInput(_testAssembly, _testXmlFile)];
     }
 
     [Fact]
     public void IconsMode_Constructor_ShouldSetCorrectMode()
     {
         // Arrange & Act
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Icons);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Icons);
 
         // Assert
         Assert.Equal(GenerationMode.Icons, generator.Mode);
@@ -45,7 +48,7 @@ public class IconEmojiTests
     public void EmojisMode_Constructor_ShouldSetCorrectMode()
     {
         // Arrange & Act
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Emojis);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Emojis);
 
         // Assert
         Assert.Equal(GenerationMode.Emojis, generator.Mode);
@@ -77,7 +80,7 @@ public class IconEmojiTests
     public void IconsMode_Generate_ShouldProduceValidJson()
     {
         // Arrange
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Icons);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Icons);
         var formatter = new JsonOutputFormatter();
 
         // Act
@@ -96,7 +99,7 @@ public class IconEmojiTests
     public void EmojisMode_Generate_ShouldProduceValidJson()
     {
         // Arrange
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Emojis);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Emojis);
         var formatter = new JsonOutputFormatter();
 
         // Act
@@ -115,7 +118,7 @@ public class IconEmojiTests
     public void IconsMode_Generate_ShouldContainExpectedStructure()
     {
         // Arrange
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Icons);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Icons);
         var formatter = new JsonOutputFormatter();
 
         // Act
@@ -152,7 +155,7 @@ public class IconEmojiTests
     public void EmojisMode_Generate_ShouldContainExpectedStructure()
     {
         // Arrange
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Emojis);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Emojis);
         var formatter = new JsonOutputFormatter();
 
         // Act
@@ -190,7 +193,7 @@ public class IconEmojiTests
     public void IconsMode_Generate_ShouldExcludeCustomSize()
     {
         // Arrange
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Icons);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Icons);
         var formatter = new JsonOutputFormatter();
 
         // Act
@@ -214,7 +217,7 @@ public class IconEmojiTests
     public void EmojisMode_Generate_ShouldExcludeCustomSize()
     {
         // Arrange
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Emojis);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Emojis);
         var formatter = new JsonOutputFormatter();
 
         // Act
@@ -241,7 +244,7 @@ public class IconEmojiTests
     public void IconsMode_SaveToFile_ShouldCreateFile()
     {
         // Arrange
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Icons);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Icons);
         var formatter = new JsonOutputFormatter();
         var outputPath = Path.Combine(Path.GetTempPath(), $"icons-test-{Guid.NewGuid()}.json");
 
@@ -273,7 +276,7 @@ public class IconEmojiTests
     public void EmojisMode_SaveToFile_ShouldCreateFile()
     {
         // Arrange
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Emojis);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Emojis);
         var formatter = new JsonOutputFormatter();
         var outputPath = Path.Combine(Path.GetTempPath(), $"emojis-test-{Guid.NewGuid()}.json");
 
@@ -306,7 +309,7 @@ public class IconEmojiTests
     {
         // Arrange
         // Create generator with Summary mode (not supported by IconsEmojisGenerator)
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Summary);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Summary);
         var formatter = new JsonOutputFormatter();
 
         // Act & Assert
@@ -317,7 +320,7 @@ public class IconEmojiTests
     public void IconsMode_Generate_ShouldOrderIconsByName()
     {
         // Arrange
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Icons);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Icons);
         var formatter = new JsonOutputFormatter();
 
         // Act
@@ -337,7 +340,7 @@ public class IconEmojiTests
     public void EmojisMode_Generate_ShouldOrderEmojisByName()
     {
         // Arrange
-        var generator = new IconsEmojisGenerator(_testAssembly, _testXmlFile, GenerationMode.Emojis);
+        var generator = new IconsEmojisGenerator(_testInputs, GenerationMode.Emojis);
         var formatter = new JsonOutputFormatter();
 
         // Act

--- a/examples/Tools/FluentUI.Demo.DocApiGen.Tests/Models/SummaryMode/ApiClassPerformanceTests.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen.Tests/Models/SummaryMode/ApiClassPerformanceTests.cs
@@ -3,6 +3,8 @@
 // ------------------------------------------------------------------------
 
 using Xunit;
+using System.Reflection;
+using FluentUI.Demo.DocApiGen.Models;
 using FluentUI.Demo.DocApiGen.Models.SummaryMode;
 using Microsoft.AspNetCore.Components;
 
@@ -21,8 +23,8 @@ public class ApiClassPerformanceTests
     {
         // Arrange
         var assembly = typeof(TestAbstractClass).Assembly;
-        var docReader = CreateMockDocReader();
-        var options = new ApiClassOptions(assembly, docReader);
+        var commentProvider = CreateMockCommentProvider(assembly);
+        var options = new ApiClassOptions(assembly, commentProvider);
 
         // Act
         var exception = Record.Exception(() =>
@@ -43,8 +45,8 @@ public class ApiClassPerformanceTests
     {
         // Arrange
         var assembly = typeof(ITestInterface).Assembly;
-        var docReader = CreateMockDocReader();
-        var options = new ApiClassOptions(assembly, docReader);
+        var commentProvider = CreateMockCommentProvider(assembly);
+        var options = new ApiClassOptions(assembly, commentProvider);
 
         // Act
         var exception = Record.Exception(() =>
@@ -65,8 +67,8 @@ public class ApiClassPerformanceTests
     {
         // Arrange
         var assembly = typeof(TestClassWithComplexConstructor).Assembly;
-        var docReader = CreateMockDocReader();
-        var options = new ApiClassOptions(assembly, docReader);
+        var commentProvider = CreateMockCommentProvider(assembly);
+        var options = new ApiClassOptions(assembly, commentProvider);
 
         // Act
         var exception = Record.Exception(() =>
@@ -87,8 +89,8 @@ public class ApiClassPerformanceTests
     {
         // Arrange
         var assembly = typeof(TestConcreteClass).Assembly;
-        var docReader = CreateMockDocReader();
-        var options = new ApiClassOptions(assembly, docReader);
+        var commentProvider = CreateMockCommentProvider(assembly);
+        var options = new ApiClassOptions(assembly, commentProvider);
 
         // Act
         var apiClass = new ApiClass(typeof(TestConcreteClass), options);
@@ -108,8 +110,8 @@ public class ApiClassPerformanceTests
     {
         // Arrange
         var assembly = typeof(TestAbstractClass).Assembly;
-        var docReader = CreateMockDocReader();
-        var options = new ApiClassOptions(assembly, docReader);
+        var commentProvider = CreateMockCommentProvider(assembly);
+        var options = new ApiClassOptions(assembly, commentProvider);
 
         var types = new[]
         {
@@ -143,9 +145,9 @@ public class ApiClassPerformanceTests
     }
 
     /// <summary>
-    /// Creates a mock DocXmlReader for testing.
+    /// Creates a mock documentation comment provider for testing.
     /// </summary>
-    private static LoxSmoke.DocXml.DocXmlReader CreateMockDocReader()
+    private static DocumentationCommentProvider CreateMockCommentProvider(Assembly assembly)
     {
         // Create a minimal XML documentation file for testing
         var xmlContent = @"<?xml version=""1.0""?>
@@ -160,7 +162,7 @@ public class ApiClassPerformanceTests
         var tempFile = Path.GetTempFileName();
         File.WriteAllText(tempFile, xmlContent);
         
-        return new LoxSmoke.DocXml.DocXmlReader(tempFile);
+        return new DocumentationCommentProvider([new DocumentationInput(assembly, new FileInfo(tempFile))]);
     }
 
     #region Test Types

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Abstractions/IDocumentationCommentProvider.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Abstractions/IDocumentationCommentProvider.cs
@@ -1,0 +1,27 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace FluentUI.Demo.DocApiGen.Abstractions;
+
+/// <summary>
+/// Provides XML documentation comments for reflected types and members.
+/// </summary>
+public interface IDocumentationCommentProvider
+{
+    /// <summary>
+    /// Gets the summary text for a type.
+    /// </summary>
+    /// <param name="type">The reflected type.</param>
+    /// <returns>The resolved summary, or an empty string.</returns>
+    string GetComponentSummary(Type type);
+
+    /// <summary>
+    /// Gets the summary text for a member.
+    /// </summary>
+    /// <param name="member">The reflected member.</param>
+    /// <returns>The resolved summary, or an empty string.</returns>
+    string GetMemberSummary(MemberInfo member);
+}

--- a/examples/Tools/FluentUI.Demo.DocApiGen/DocumentationAssemblyLoadContext.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/DocumentationAssemblyLoadContext.cs
@@ -1,0 +1,83 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace FluentUI.Demo.DocApiGen;
+
+/// <summary>
+/// Loads documentation target assemblies and their dependencies in an isolated context.
+/// </summary>
+public sealed class DocumentationAssemblyLoadContext : AssemblyLoadContext
+{
+    private readonly Dictionary<string, string> _inputAssemblyPaths;
+    private readonly IReadOnlyList<AssemblyDependencyResolver> _resolvers;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentationAssemblyLoadContext"/> class.
+    /// </summary>
+    /// <param name="assemblyPaths">The assembly paths that can be loaded as documentation inputs.</param>
+    public DocumentationAssemblyLoadContext(IEnumerable<string> assemblyPaths)
+        : base(nameof(DocumentationAssemblyLoadContext), isCollectible: false)
+    {
+        _inputAssemblyPaths = assemblyPaths
+            .ToDictionary(
+                path => Path.GetFileNameWithoutExtension(path),
+                StringComparer.OrdinalIgnoreCase);
+
+#pragma warning disable CA1416 // Validate platform compatibility
+        _resolvers = _inputAssemblyPaths.Values
+            .Select(path => new AssemblyDependencyResolver(path))
+            .ToArray();
+#pragma warning restore CA1416 // Validate platform compatibility
+    }
+
+    /// <summary>
+    /// Resolves managed assemblies for the documentation inputs and their dependencies.
+    /// </summary>
+    /// <param name="assemblyName">The assembly name to resolve.</param>
+    /// <returns>The loaded assembly if resolution succeeds; otherwise, <see langword="null"/>.</returns>
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        if (!string.IsNullOrEmpty(assemblyName.Name) && _inputAssemblyPaths.TryGetValue(assemblyName.Name, out var inputAssemblyPath))
+        {
+            return LoadFromAssemblyPath(inputAssemblyPath);
+        }
+
+        foreach (var resolver in _resolvers)
+        {
+#pragma warning disable CA1416 // Validate platform compatibility
+            var assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
+#pragma warning restore CA1416 // Validate platform compatibility
+            if (!string.IsNullOrEmpty(assemblyPath))
+            {
+                return LoadFromAssemblyPath(assemblyPath);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves unmanaged libraries for the documentation inputs and their dependencies.
+    /// </summary>
+    /// <param name="unmanagedDllName">The unmanaged library name to resolve.</param>
+    /// <returns>A native library handle if resolution succeeds; otherwise, <c>0</c>.</returns>
+    protected override nint LoadUnmanagedDll(string unmanagedDllName)
+    {
+        foreach (var resolver in _resolvers)
+        {
+#pragma warning disable CA1416 // Validate platform compatibility
+            var unmanagedDllPath = resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+#pragma warning restore CA1416 // Validate platform compatibility
+            if (!string.IsNullOrEmpty(unmanagedDllPath))
+            {
+                return LoadUnmanagedDllFromPath(unmanagedDllPath);
+            }
+        }
+
+        return 0;
+    }
+}

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Generators/AllDocumentationGenerator.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Generators/AllDocumentationGenerator.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Reflection;
 using FluentUI.Demo.DocApiGen.Abstractions;
 using FluentUI.Demo.DocApiGen.Extensions;
+using FluentUI.Demo.DocApiGen.Models;
 using FluentUI.Demo.DocApiGen.Models.AllMode;
 using FluentUI.Demo.DocApiGen.Models.SummaryMode;
 
@@ -17,17 +18,16 @@ namespace FluentUI.Demo.DocApiGen.Generators;
 /// </summary>
 public sealed class AllDocumentationGenerator : DocumentationGeneratorBase
 {
-    private readonly LoxSmoke.DocXml.DocXmlReader _docXmlReader;
+    private readonly DocumentationCommentProvider _commentProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AllDocumentationGenerator"/> class.
     /// </summary>
-    /// <param name="assembly">The assembly to generate documentation for.</param>
-    /// <param name="xmlDocumentation">The XML documentation file.</param>
-    public AllDocumentationGenerator(Assembly assembly, FileInfo xmlDocumentation)
-        : base(assembly, xmlDocumentation)
+    /// <param name="inputs">The documentation inputs to generate documentation for.</param>
+    public AllDocumentationGenerator(IReadOnlyList<DocumentationInput> inputs)
+        : base(inputs)
     {
-        _docXmlReader = new LoxSmoke.DocXml.DocXmlReader(xmlDocumentation.FullName);
+        _commentProvider = new DocumentationCommentProvider(inputs);
     }
 
     /// <inheritdoc/>
@@ -57,8 +57,9 @@ public sealed class AllDocumentationGenerator : DocumentationGeneratorBase
         var components = new List<ComponentInfo>();
         var enums = new List<EnumInfo>();
 
-        var validTypes = Assembly.GetTypes().Where(IsValidComponentType).ToList();
-        var enumTypes = Assembly.GetTypes().Where(t => t.IsEnum && t.IsPublic).ToList();
+        var allTypes = Inputs.SelectMany(input => input.Assembly.GetTypes()).ToList();
+        var validTypes = allTypes.Where(IsValidComponentType).ToList();
+        var enumTypes = allTypes.Where(t => t.IsEnum && t.IsPublic).ToList();
 
         Console.WriteLine($"Processing {validTypes.Count} components and {enumTypes.Count} enums...");
 
@@ -112,7 +113,7 @@ public sealed class AllDocumentationGenerator : DocumentationGeneratorBase
     {
         try
         {
-            var options = new ApiClassOptions(Assembly, _docXmlReader)
+            var options = new ApiClassOptions(type.Assembly, _commentProvider)
             {
                 Mode = GenerationMode.All
             };
@@ -211,7 +212,7 @@ public sealed class AllDocumentationGenerator : DocumentationGeneratorBase
             var name = names[i];
             var value = Convert.ToInt32(enumValues.GetValue(i), CultureInfo.InvariantCulture);
             var field = type.GetField(name);
-            var description = field != null ? _docXmlReader.GetMemberSummary(field) : string.Empty;
+            var description = field != null ? _commentProvider.GetMemberSummary(field) : string.Empty;
 
             values.Add(new EnumValueInfo
             {
@@ -221,7 +222,7 @@ public sealed class AllDocumentationGenerator : DocumentationGeneratorBase
             });
         }
 
-        var enumDescription = _docXmlReader.GetComponentSummary(type);
+        var enumDescription = _commentProvider.GetComponentSummary(type);
 
         return new EnumInfo
         {
@@ -314,7 +315,7 @@ public sealed class AllDocumentationGenerator : DocumentationGeneratorBase
     {
         var version = "Unknown";
 
-        var versionAttribute = Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        var versionAttribute = PrimaryAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
         if (versionAttribute != null)
         {
             var versionString = versionAttribute.InformationalVersion;

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Generators/DocumentationGeneratorBase.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Generators/DocumentationGeneratorBase.cs
@@ -4,6 +4,7 @@
 
 using System.Reflection;
 using FluentUI.Demo.DocApiGen.Abstractions;
+using FluentUI.Demo.DocApiGen.Models;
 
 namespace FluentUI.Demo.DocApiGen.Generators;
 
@@ -13,29 +14,34 @@ namespace FluentUI.Demo.DocApiGen.Generators;
 public abstract class DocumentationGeneratorBase : IDocumentationGenerator
 {
     /// <summary>
-    /// Represents the assembly associated with the current context or operation.
+    /// Represents the documentation inputs associated with the current operation.
     /// </summary>
-    protected readonly Assembly Assembly;
+    protected readonly IReadOnlyList<DocumentationInput> Inputs;
 
     /// <summary>
-    /// Represents the XML documentation file associated with the assembly.
+    /// Gets the primary documentation input.
     /// </summary>
-    protected readonly FileInfo XmlDocumentation;
+    protected DocumentationInput PrimaryInput => Inputs[0];
+
+    /// <summary>
+    /// Gets the primary assembly.
+    /// </summary>
+    protected Assembly PrimaryAssembly => PrimaryInput.Assembly;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DocumentationGeneratorBase"/> class.
     /// </summary>
-    /// <param name="assembly">The assembly to generate documentation for.</param>
-    /// <param name="xmlDocumentation">The XML documentation file.</param>
-    protected DocumentationGeneratorBase(Assembly assembly, FileInfo xmlDocumentation)
+    /// <param name="inputs">The documentation inputs to generate documentation for.</param>
+    protected DocumentationGeneratorBase(IReadOnlyList<DocumentationInput> inputs)
     {
-        Assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
-        XmlDocumentation = xmlDocumentation ?? throw new ArgumentNullException(nameof(xmlDocumentation));
+        ArgumentNullException.ThrowIfNull(inputs);
 
-        if (!xmlDocumentation.Exists)
+        if (inputs.Count == 0)
         {
-            throw new FileNotFoundException($"XML documentation file not found: {xmlDocumentation.FullName}");
+            throw new ArgumentException("At least one documentation input is required.", nameof(inputs));
         }
+
+        Inputs = inputs;
     }
 
     /// <inheritdoc/>

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Generators/DocumentationGeneratorFactory.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Generators/DocumentationGeneratorFactory.cs
@@ -4,6 +4,7 @@
 
 using System.Reflection;
 using FluentUI.Demo.DocApiGen.Abstractions;
+using FluentUI.Demo.DocApiGen.Models;
 
 namespace FluentUI.Demo.DocApiGen.Generators;
 
@@ -16,29 +17,43 @@ public static class DocumentationGeneratorFactory
     /// Creates a documentation generator for the specified mode.
     /// </summary>
     /// <param name="mode">The generation mode.</param>
+    /// <param name="inputs">The documentation inputs to generate documentation for.</param>
+    /// <returns>A documentation generator instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when inputs is null.</exception>
+    /// <exception cref="NotSupportedException">Thrown when the mode is not supported.</exception>
+    public static IDocumentationGenerator Create(
+        GenerationMode mode,
+        IReadOnlyList<DocumentationInput> inputs)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+
+        return mode switch
+        {
+            GenerationMode.Summary => new SummaryDocumentationGenerator(inputs),
+            GenerationMode.All => new AllDocumentationGenerator(inputs),
+            GenerationMode.Mcp => new McpDocumentationGenerator(inputs),
+            GenerationMode.Icons => new IconsEmojisGenerator(inputs, mode),
+            GenerationMode.Emojis => new IconsEmojisGenerator(inputs, mode),
+            _ => throw new NotSupportedException($"Generation mode '{mode}' is not supported.")
+        };
+    }
+
+    /// <summary>
+    /// Creates a documentation generator for the specified mode.
+    /// </summary>
+    /// <param name="mode">The generation mode.</param>
     /// <param name="assembly">The assembly to generate documentation for.</param>
     /// <param name="xmlDocumentation">The XML documentation file.</param>
     /// <returns>A documentation generator instance.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when assembly or xmlDocumentation is null.</exception>
-    /// <exception cref="NotSupportedException">Thrown when the mode is not supported.</exception>
     public static IDocumentationGenerator Create(
         GenerationMode mode,
         Assembly assembly,
         FileInfo xmlDocumentation)
     {
         ArgumentNullException.ThrowIfNull(assembly);
-
         ArgumentNullException.ThrowIfNull(xmlDocumentation);
 
-        return mode switch
-        {
-            GenerationMode.Summary => new SummaryDocumentationGenerator(assembly, xmlDocumentation),
-            GenerationMode.All => new AllDocumentationGenerator(assembly, xmlDocumentation),
-            GenerationMode.Mcp => new McpDocumentationGenerator(assembly, xmlDocumentation),
-            GenerationMode.Icons => new IconsEmojisGenerator(assembly, xmlDocumentation, mode),
-            GenerationMode.Emojis => new IconsEmojisGenerator(assembly, xmlDocumentation, mode),
-            _ => throw new NotSupportedException($"Generation mode '{mode}' is not supported.")
-        };
+        return Create(mode, [new DocumentationInput(assembly, xmlDocumentation)]);
     }
 
     /// <summary>

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Generators/IconsEmojisGenerator.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Generators/IconsEmojisGenerator.cs
@@ -2,9 +2,9 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
-using System.Reflection;
 using System.Text.Json;
 using FluentUI.Demo.DocApiGen.Abstractions;
+using FluentUI.Demo.DocApiGen.Models;
 
 namespace FluentUI.Demo.DocApiGen.Generators;
 
@@ -18,11 +18,10 @@ public sealed class IconsEmojisGenerator : DocumentationGeneratorBase
     /// <summary>
     /// Initializes a new instance of the <see cref="IconsEmojisGenerator"/> class.
     /// </summary>
-    /// <param name="assembly">The assembly to generate documentation for.</param>
-    /// <param name="xmlDocumentation">The XML documentation file.</param>
+    /// <param name="inputs">The documentation inputs to generate documentation for.</param>
     /// <param name="mode">The generation mode (Icons or Emojis).</param>
-    public IconsEmojisGenerator(Assembly assembly, FileInfo xmlDocumentation, GenerationMode mode)
-        : base(assembly, xmlDocumentation)
+    public IconsEmojisGenerator(IReadOnlyList<DocumentationInput> inputs, GenerationMode mode)
+        : base(inputs)
     {
         _mode = mode;
     }

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Generators/McpDocumentationGenerator.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Generators/McpDocumentationGenerator.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
 using FluentUI.Demo.DocApiGen.Abstractions;
-using FluentUI.Demo.DocApiGen.Extensions;
+using FluentUI.Demo.DocApiGen.Models;
 using FluentUI.Demo.DocApiGen.Models.McpMode;
 
 namespace FluentUI.Demo.DocApiGen.Generators;
@@ -17,7 +17,7 @@ namespace FluentUI.Demo.DocApiGen.Generators;
 /// </summary>
 public sealed class McpDocumentationGenerator : DocumentationGeneratorBase
 {
-    private readonly LoxSmoke.DocXml.DocXmlReader _docXmlReader;
+    private readonly DocumentationCommentProvider _commentProvider;
 
     // MCP attribute type names (we check by name to avoid assembly dependency)
     private const string McpServerToolTypeAttribute = "McpServerToolTypeAttribute";
@@ -30,12 +30,11 @@ public sealed class McpDocumentationGenerator : DocumentationGeneratorBase
     /// <summary>
     /// Initializes a new instance of the <see cref="McpDocumentationGenerator"/> class.
     /// </summary>
-    /// <param name="assembly">The assembly to generate documentation for.</param>
-    /// <param name="xmlDocumentation">The XML documentation file.</param>
-    public McpDocumentationGenerator(Assembly assembly, FileInfo xmlDocumentation)
-        : base(assembly, xmlDocumentation)
+    /// <param name="inputs">The documentation inputs to generate documentation for.</param>
+    public McpDocumentationGenerator(IReadOnlyList<DocumentationInput> inputs)
+        : base(inputs)
     {
-        _docXmlReader = new LoxSmoke.DocXml.DocXmlReader(xmlDocumentation.FullName);
+        _commentProvider = new DocumentationCommentProvider(inputs);
     }
 
     /// <inheritdoc/>
@@ -66,7 +65,10 @@ public sealed class McpDocumentationGenerator : DocumentationGeneratorBase
         var resources = new List<McpResourceInfo>();
         var prompts = new List<McpPromptInfo>();
 
-        var allTypes = Assembly.GetTypes().Where(t => t.IsClass && t.IsPublic && !t.IsAbstract).ToList();
+        var allTypes = Inputs
+            .SelectMany(input => input.Assembly.GetTypes())
+            .Where(t => t.IsClass && t.IsPublic && !t.IsAbstract)
+            .ToList();
 
         Console.WriteLine($"Scanning {allTypes.Count} types for MCP attributes...");
 
@@ -125,7 +127,7 @@ public sealed class McpDocumentationGenerator : DocumentationGeneratorBase
     {
         try
         {
-            var xmlSummary = _docXmlReader.GetMemberSummary(method);
+            var xmlSummary = _commentProvider.GetMemberSummary(method);
             var description = GetDescriptionAttribute(method);
 
             var parameters = ExtractMethodParameters(method);
@@ -154,7 +156,7 @@ public sealed class McpDocumentationGenerator : DocumentationGeneratorBase
     {
         try
         {
-            var xmlSummary = _docXmlReader.GetMemberSummary(method);
+            var xmlSummary = _commentProvider.GetMemberSummary(method);
             var description = GetDescriptionAttribute(method);
             var resourceAttr = GetResourceAttributeProperties(method);
 
@@ -192,7 +194,7 @@ public sealed class McpDocumentationGenerator : DocumentationGeneratorBase
     {
         try
         {
-            var xmlSummary = _docXmlReader.GetMemberSummary(method);
+            var xmlSummary = _commentProvider.GetMemberSummary(method);
             var description = GetDescriptionAttribute(method);
 
             var parameters = ExtractMethodParameters(method);
@@ -355,7 +357,7 @@ public sealed class McpDocumentationGenerator : DocumentationGeneratorBase
     {
         var version = "Unknown";
 
-        var versionAttribute = Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        var versionAttribute = PrimaryAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
         if (versionAttribute != null)
         {
             var versionString = versionAttribute.InformationalVersion;

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Generators/SummaryDocumentationGenerator.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Generators/SummaryDocumentationGenerator.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Reflection;
 using FluentUI.Demo.DocApiGen.Abstractions;
 using FluentUI.Demo.DocApiGen.Extensions;
+using FluentUI.Demo.DocApiGen.Models;
 using FluentUI.Demo.DocApiGen.Models.SummaryMode;
 
 namespace FluentUI.Demo.DocApiGen.Generators;
@@ -16,17 +17,16 @@ namespace FluentUI.Demo.DocApiGen.Generators;
 /// </summary>
 public sealed class SummaryDocumentationGenerator : DocumentationGeneratorBase
 {
-    private readonly LoxSmoke.DocXml.DocXmlReader _docXmlReader;
+    private readonly DocumentationCommentProvider _commentProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SummaryDocumentationGenerator"/> class.
     /// </summary>
-    /// <param name="assembly">The assembly to generate documentation for.</param>
-    /// <param name="xmlDocumentation">The XML documentation file.</param>
-    public SummaryDocumentationGenerator(Assembly assembly, FileInfo xmlDocumentation)
-        : base(assembly, xmlDocumentation)
+    /// <param name="inputs">The documentation inputs to generate documentation for.</param>
+    public SummaryDocumentationGenerator(IReadOnlyList<DocumentationInput> inputs)
+        : base(inputs)
     {
-        _docXmlReader = new LoxSmoke.DocXml.DocXmlReader(xmlDocumentation.FullName);
+        _commentProvider = new DocumentationCommentProvider(inputs);
     }
 
     /// <inheritdoc/>
@@ -49,13 +49,32 @@ public sealed class SummaryDocumentationGenerator : DocumentationGeneratorBase
         var (version, date) = GetAssemblyInfo();
         var components = new Dictionary<string, ComponentEntry>();
 
-        var options = new ApiClassOptions(Assembly, _docXmlReader)
+        var options = new ApiClassOptions(PrimaryAssembly, _commentProvider)
         {
             Mode = GenerationMode.Summary,
             PropertyParameterOnly = false,
         };
 
-        var validTypes = Assembly.GetTypes().Where(t => t.IsValidType()).ToList();
+        var validTypes = Inputs
+    .SelectMany(input =>
+    {
+        try
+        {
+            return input.Assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            Console.WriteLine($"[WARNING] Could not load all types from {input.Assembly.FullName}");
+            foreach (var loaderException in ex.LoaderExceptions.Where(e => e is not null))
+            {
+                Console.WriteLine($"  - {loaderException!.Message}");
+            }
+
+            return ex.Types.OfType<Type>();
+        }
+    })
+    .Where(t => t.IsValidType())
+    .ToList();
         Console.WriteLine($"Processing {validTypes.Count} valid types...");
 
         var processedCount = 0;
@@ -123,7 +142,7 @@ public sealed class SummaryDocumentationGenerator : DocumentationGeneratorBase
     {
         var version = "Unknown";
 
-        var versionAttribute = Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+        var versionAttribute = PrimaryAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
         if (versionAttribute != null)
         {
             var versionString = versionAttribute.InformationalVersion;

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Models/DocumentationCommentProvider.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Models/DocumentationCommentProvider.cs
@@ -1,0 +1,67 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Reflection;
+using FluentUI.Demo.DocApiGen.Abstractions;
+using FluentUI.Demo.DocApiGen.Extensions;
+
+namespace FluentUI.Demo.DocApiGen.Models;
+
+/// <summary>
+/// Resolves XML documentation comments across one or more documentation inputs.
+/// </summary>
+public sealed class DocumentationCommentProvider : IDocumentationCommentProvider
+{
+    private readonly IReadOnlyDictionary<Assembly, DocumentationInput> _inputsByAssembly;
+    private readonly IReadOnlyList<DocumentationInput> _inputs;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentationCommentProvider"/> class.
+    /// </summary>
+    /// <param name="inputs">The documentation inputs to resolve comments from.</param>
+    public DocumentationCommentProvider(IReadOnlyList<DocumentationInput> inputs)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+
+        if (inputs.Count == 0)
+        {
+            throw new ArgumentException("At least one documentation input is required.", nameof(inputs));
+        }
+
+        _inputs = inputs;
+        _inputsByAssembly = inputs.ToDictionary(input => input.Assembly);
+    }
+
+    /// <inheritdoc/>
+    public string GetComponentSummary(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        return TryGetInput(type.Assembly, out var input)
+            ? input.DocXmlReader.GetComponentSummary(type)
+            : string.Empty;
+    }
+
+    /// <inheritdoc/>
+    public string GetMemberSummary(MemberInfo member)
+    {
+        ArgumentNullException.ThrowIfNull(member);
+
+        var assembly = member.Module.Assembly;
+        return TryGetInput(assembly, out var input)
+            ? input.DocXmlReader.GetMemberSummary(member)
+            : string.Empty;
+    }
+
+    private bool TryGetInput(Assembly assembly, out DocumentationInput input)
+    {
+        if (_inputsByAssembly.TryGetValue(assembly, out input!))
+        {
+            return true;
+        }
+
+        input = _inputs[0];
+        return false;
+    }
+}

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Models/DocumentationInput.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Models/DocumentationInput.cs
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace FluentUI.Demo.DocApiGen.Models;
+
+/// <summary>
+/// Represents one documentation source consisting of an assembly and its XML documentation file.
+/// </summary>
+public sealed class DocumentationInput
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentationInput"/> class.
+    /// </summary>
+    /// <param name="assembly">The assembly to document.</param>
+    /// <param name="xmlDocumentation">The XML documentation file associated with the assembly.</param>
+    public DocumentationInput(Assembly assembly, FileInfo xmlDocumentation)
+    {
+        Assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
+        XmlDocumentation = xmlDocumentation ?? throw new ArgumentNullException(nameof(xmlDocumentation));
+
+        if (!xmlDocumentation.Exists)
+        {
+            throw new FileNotFoundException($"XML documentation file not found: {xmlDocumentation.FullName}");
+        }
+
+        DocXmlReader = new LoxSmoke.DocXml.DocXmlReader(xmlDocumentation.FullName);
+    }
+
+    /// <summary>
+    /// Gets the assembly to document.
+    /// </summary>
+    public Assembly Assembly { get; }
+
+    /// <summary>
+    /// Gets the XML documentation file associated with the assembly.
+    /// </summary>
+    public FileInfo XmlDocumentation { get; }
+
+    /// <summary>
+    /// Gets the XML documentation reader for the assembly.
+    /// </summary>
+    public LoxSmoke.DocXml.DocXmlReader DocXmlReader { get; }
+}

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Models/SummaryMode/ApiClass.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Models/SummaryMode/ApiClass.cs
@@ -328,8 +328,8 @@ public class ApiClass
     private string GetSummary(Type component, MemberInfo? member)
     {
         return member == null
-             ? _options.DocXmlReader.GetComponentSummary(component)
-             : _options.DocXmlReader.GetMemberSummary(member);
+             ? _options.CommentProvider.GetComponentSummary(component)
+             : _options.CommentProvider.GetMemberSummary(member);
     }
 
     /// <summary>

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Models/SummaryMode/ApiClassOptions.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Models/SummaryMode/ApiClassOptions.cs
@@ -16,11 +16,11 @@ public class ApiClassOptions
     /// Initializes a new instance of the <see cref="ApiClassOptions"/> class.
     /// </summary>
     /// <param name="assembly"></param>
-    /// <param name="docReader"></param>
-    public ApiClassOptions(Assembly assembly, LoxSmoke.DocXml.DocXmlReader docReader)
+    /// <param name="commentProvider"></param>
+    public ApiClassOptions(Assembly assembly, IDocumentationCommentProvider commentProvider)
     {
         Assembly = assembly;
-        DocXmlReader = docReader;
+        CommentProvider = commentProvider;
     }
 
     /// <summary>
@@ -29,9 +29,9 @@ public class ApiClassOptions
     public Assembly Assembly { get; }
 
     /// <summary>
-    /// Gets the summary reader.
+    /// Gets the summary provider.
     /// </summary>
-    public LoxSmoke.DocXml.DocXmlReader DocXmlReader { get; }
+    public IDocumentationCommentProvider CommentProvider { get; }
 
     /// <summary>
     /// Gets or sets whether to include all properties (false) or only those with [Parameter] attribute (true).

--- a/examples/Tools/FluentUI.Demo.DocApiGen/Program.cs
+++ b/examples/Tools/FluentUI.Demo.DocApiGen/Program.cs
@@ -2,11 +2,12 @@
 // This file is licensed to you under the MIT License.
 // ------------------------------------------------------------------------
 
+using System.Reflection;
 using FluentUI.Demo.DocApiGen.Abstractions;
 using FluentUI.Demo.DocApiGen.Formatters;
 using FluentUI.Demo.DocApiGen.Generators;
+using FluentUI.Demo.DocApiGen.Models;
 using Microsoft.Extensions.Configuration;
-using System.Reflection;
 
 namespace FluentUI.Demo.DocApiGen;
 
@@ -16,6 +17,7 @@ namespace FluentUI.Demo.DocApiGen;
 public class Program
 {
     private static readonly System.Diagnostics.Stopwatch _watcher = new();
+    private static readonly char[] InputSeparators = [';', '|'];
 
     /// <summary>
     /// Main method.
@@ -32,22 +34,18 @@ public class Program
 
         // Build a configuration object from command line
         var config = new ConfigurationBuilder().AddCommandLine(args).Build();
-        var xmlFile = config["xml"];
-        var dllFile = config["dll"];
+        var xmlFiles = config["xml"];
+        var dllFiles = config["dll"];
         var outputFile = config["output"];
         var format = config["format"] ?? "json";
         var modeArg = config["mode"] ?? "summary";
 
         // Help
-        if (string.IsNullOrEmpty(xmlFile) || string.IsNullOrEmpty(dllFile))
+        if (string.IsNullOrEmpty(xmlFiles) || string.IsNullOrEmpty(dllFiles))
         {
             ShowHelp();
             return;
         }
-
-        // Ensure dllFile and xmlFile are absolute paths
-        dllFile = Path.IsPathRooted(dllFile) ? dllFile : Path.Combine(Directory.GetCurrentDirectory(), dllFile);
-        xmlFile = Path.IsPathRooted(xmlFile) ? xmlFile : Path.Combine(Directory.GetCurrentDirectory(), xmlFile);
 
         try
         {
@@ -57,18 +55,17 @@ public class Program
             // Validate format compatibility
             ValidateFormatCompatibility(mode, format);
 
-            // Load assembly and XML documentation
-            var assembly = Assembly.LoadFile(dllFile);
-            var docXml = new FileInfo(xmlFile);
+            // Load assemblies and XML documentation
+            var inputs = CreateDocumentationInputs(dllFiles, xmlFiles);
 
             Console.WriteLine("Generating documentation...");
-            Console.WriteLine($"  Assembly: {assembly.GetName().Name}");
+            Console.WriteLine($"  Assemblies: {string.Join(", ", inputs.Select(input => input.Assembly.GetName().Name))}");
             Console.WriteLine($"  Mode: {mode}");
             Console.WriteLine($"  Format: {format}");
             Console.WriteLine();
 
             // Create generator and formatter
-            var generator = DocumentationGeneratorFactory.Create(mode, assembly, docXml);
+            var generator = DocumentationGeneratorFactory.Create(mode, inputs);
             var formatter = OutputFormatterFactory.Create(format);
 
             // Generate and output
@@ -101,18 +98,18 @@ public class Program
                 Console.ResetColor();
             }
 
-            Environment.Exit(1);
+            //Environment.Exit(1);
         }
     }
 
     private static void ShowHelp()
     {
         Console.WriteLine("Usage:");
-        Console.WriteLine("  DocApiGen --xml <xml_file> --dll <dll_file> [options]");
+        Console.WriteLine("  DocApiGen --xml <xml_file[;xml_file2]> --dll <dll_file[;dll_file2]> [options]");
         Console.WriteLine();
         Console.WriteLine("Required Arguments:");
-        Console.WriteLine("  --xml <file>      Path to the XML documentation file");
-        Console.WriteLine("  --dll <file>      Path to the assembly DLL file");
+        Console.WriteLine("  --xml <file>      Path to the XML documentation file, or multiple paths separated by ';' or '|'");
+        Console.WriteLine("  --dll <file>      Path to the assembly DLL file, or multiple paths separated by ';' or '|'");
         Console.WriteLine();
         Console.WriteLine("Optional Arguments:");
         Console.WriteLine("  --output <file>   Path to the output file (default: stdout)");
@@ -144,6 +141,9 @@ public class Program
         Console.WriteLine();
         Console.WriteLine("  # Generate All mode JSON");
         Console.WriteLine("  DocApiGen --xml MyApp.xml --dll MyApp.dll --output api-all.json --mode all");
+        Console.WriteLine();
+        Console.WriteLine("  # Generate Summary mode JSON from multiple assemblies");
+        Console.WriteLine("  DocApiGen --xml Core.xml;Charts.xml --dll Core.dll;Charts.dll --output api-summary.json");
         Console.WriteLine();
         Console.WriteLine("  # Generate MCP documentation JSON");
         Console.WriteLine("  DocApiGen --xml McpServer.xml --dll McpServer.dll --output mcp-docs.json --mode mcp");
@@ -192,5 +192,61 @@ public class Program
             throw new NotSupportedException(
                 $"Mode '{mode}' only supports JSON format. Requested format: {format}");
         }
+    }
+
+    private static IReadOnlyList<DocumentationInput> CreateDocumentationInputs(string dllFiles, string xmlFiles)
+    {
+        var dllPaths = SplitInputValues(dllFiles)
+            .Select(MakeAbsolutePath)
+            .ToArray();
+
+        var xmlPaths = SplitInputValues(xmlFiles)
+            .Select(MakeAbsolutePath)
+            .ToArray();
+
+        if (dllPaths.Length != xmlPaths.Length)
+        {
+            throw new ArgumentException($"The number of DLL files ({dllPaths.Length}) must match the number of XML files ({xmlPaths.Length}).");
+        }
+
+        var loadContext = new DocumentationAssemblyLoadContext(dllPaths);
+
+        return dllPaths
+            .Select((dllPath, index) =>
+            {
+                Console.WriteLine($"Attempting to load assembly: {dllPath}");
+
+                try
+                {
+                    var assembly = loadContext.LoadFromAssemblyPath(dllPath);
+
+                    Console.WriteLine($"  Loaded input assembly: {assembly.GetName().Name}");
+                    Console.WriteLine($"    Requested path: {dllPath}");
+                    Console.WriteLine($"    FullName: {assembly.FullName}");
+                    Console.WriteLine($"    Location: {assembly.Location}");
+
+                    return new DocumentationInput(assembly, new FileInfo(xmlPaths[index]));
+                }
+                catch (FileLoadException ex)
+                {
+                    Console.WriteLine($"  Failed to load assembly: {dllPath}");
+                    Console.WriteLine($"  {ex.Message}");
+                    throw;
+                }
+            })
+            .ToArray();
+    }
+
+    private static IEnumerable<string> SplitInputValues(string value)
+    {
+        return value
+            .Split(InputSeparators, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Where(static path => !string.IsNullOrWhiteSpace(path));
+    }
+    private static string MakeAbsolutePath(string path)
+    {
+        return Path.IsPathRooted(path)
+            ? path
+            : Path.Combine(Directory.GetCurrentDirectory(), path);
     }
 }

--- a/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Components/MarkdownViewer.razor.cs
@@ -139,11 +139,7 @@ public partial class MarkdownViewer
         }
 
         // Get the component type
-        var type = DocViewerService.ApiAssembly
-                                  ?.GetTypes()
-                                  ?.FirstOrDefault(i => i.Name == componentName
-                                                     || i.Name.StartsWith($"{componentName}`1")
-                                                     || i.Name.StartsWith($"{componentName}`2"));
+        var type = DocViewerService.FindApiType(componentName);
 
         // Create the ApiClass
         var result = type is null ? null : new ApiClass(DocViewerService, type, allProperties);
@@ -165,7 +161,6 @@ public partial class MarkdownViewer
                 }
             }
 
-            
             result.InstanceTypes = listOfTypes.ToArray();
         }
 

--- a/examples/Tools/FluentUI.Demo.DocViewer/Services/DocViewerOptions.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Services/DocViewerOptions.cs
@@ -29,7 +29,17 @@ public class DocViewerOptions
     /// <summary>
     /// Assembly containing the API classes to display in API sections.
     /// </summary>
-    public Assembly? ApiAssembly { get; set; }
+    public IReadOnlyList<Assembly> ApiAssemblies { get; set; } = [];
+
+    /// <summary>
+    /// Assembly containing the API classes to display in API sections.
+    /// </summary>
+    [Obsolete("Use ApiAssemblies instead.")]
+    public Assembly? ApiAssembly
+    {
+        get => ApiAssemblies.Count > 0 ? ApiAssemblies[0] : null;
+        set => ApiAssemblies = value is null ? [] : [value];
+    }
 
     /// <summary>
     /// Function to get the summary of an API comment.

--- a/examples/Tools/FluentUI.Demo.DocViewer/Services/DocViewerService.cs
+++ b/examples/Tools/FluentUI.Demo.DocViewer/Services/DocViewerService.cs
@@ -30,7 +30,7 @@ public class DocViewerService
         Options = options;
         ComponentsAssembly = options.ComponentsAssembly;
         ResourcesAssembly = options.ResourcesAssembly;
-        ApiAssembly = options.ApiAssembly;
+        ApiAssemblies = options.ApiAssemblies;
         ApiCommentSummary = options.ApiCommentSummary;
     }
 
@@ -50,9 +50,15 @@ public class DocViewerService
     public Assembly? ResourcesAssembly { get; }
 
     /// <summary>
-    /// Gets the assembly containing the classes to display in API sections.
+    /// Gets the assemblies containing the classes to display in API sections.
     /// </summary>
-    public Assembly? ApiAssembly { get; }
+    public IReadOnlyList<Assembly> ApiAssemblies { get; }
+
+    /// <summary>
+    /// Gets the primary assembly containing the classes to display in API sections.
+    /// </summary>
+    [Obsolete("Use ApiAssemblies instead.")]
+    public Assembly? ApiAssembly => ApiAssemblies.Count > 0 ? ApiAssemblies[0] : null;
 
     /// <summary>
     /// Function to get the summary of an API comment.
@@ -63,6 +69,33 @@ public class DocViewerService
     /// Gets the list of all markdown pages found in the resources
     /// </summary>
     public IEnumerable<Page> Pages => _pages ??= LoadAllPages();
+
+    /// <summary>
+    /// Returns the <see cref="Type"/> associated to the <paramref name="fullName"/>.
+    /// </summary>
+    /// <param name="fullName">The full name of the type.</param>
+    /// <returns>The <see cref="Type"/> if found; otherwise, <c>null</c>.</returns>
+    public Type? FindApiType(string fullName)
+    {
+        if (string.IsNullOrWhiteSpace(fullName))
+        {
+            return null;
+        }
+
+        foreach (var assembly in ApiAssemblies)
+        {
+            var type = assembly.GetType(fullName, throwOnError: false, ignoreCase: false);
+            if (type is not null)
+            {
+                return type;
+            }
+        }
+
+        return ApiAssemblies
+            .SelectMany(GetTypes)
+            .FirstOrDefault(type => string.Equals(type.FullName, fullName, StringComparison.Ordinal)
+                                 || string.Equals(type.Name, fullName, StringComparison.Ordinal));
+    }
 
     /// <summary>
     /// Returns the <see cref="Page" /> associated to the <paramref name="routeName"/>.
@@ -145,5 +178,18 @@ public class DocViewerService
         }
 
         return pages.Where(i => !string.IsNullOrEmpty(i.Route)).OrderBy(i => i.Route);
+    }
+
+    /// <summary />
+    private static IEnumerable<Type> GetTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.OfType<Type>();
+        }
     }
 }


### PR DESCRIPTION
This pull request refactors the documentation generator to support multiple documentation inputs and assemblies. You can now specify multiple dll and xml sources to generate one combined api-comments.json file. 
It replaces the old single-assembly generator creation with a new approach using `DocumentationInput` and `GenerationMode`. Some utility methods and test setup logic are also improved for better robustness. For instance, we now use a specialized (isolated) AssemblyLoadContext so errors about mismatching assembly manifests are now prevented.
The PR also updates the `MarkdownViewer` to read from multiple assembly documentation sources

**Test Infrastructure Improvements:**

* Refactored test setup to use `DocumentationInput` and `GenerationMode` with the `DocumentationGeneratorFactory.Create` method, replacing the previous single-assembly generator creation methods. This enables easier extension to multiple assemblies and modes. 

* Added a new test (`AllGenerator_WithMultipleDocumentationInputs_ShouldIncludeChartsAssemblyTypes`) that verifies the generator can handle multiple assemblies and documentation files, ensuring types from both the core and charts assemblies are included in the output.

**Utility and Robustness Improvements:**

* Centralized assembly path resolution with a new `GetAssemblyPath` method, supporting both Debug and Release builds, improving reliability when locating assemblies for tests.

* Updated project root directory detection to look for `.slnx` files instead of `.sln`, reflecting the current solution file extension.

**Demo Service Registration:**

* Updated `AddFluentUIDemoServices` to use the `ApiAssemblies` property (now an array) instead of the deprecated `ApiAssembly` property, aligning with new API expectations.