### PR TITLE
[dev-v5] Add nullable object support in "FluentList"

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Autocomplete/DebugPages/SelectDebug.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Autocomplete/DebugPages/SelectDebug.razor
@@ -1,0 +1,21 @@
+﻿@page "/Lists/Select/Debug"
+
+@using static FluentUI.Demo.SampleData.Olympics2024
+
+<div style="margin: 24px;">
+    <h2>4705 - Nullable support in FluentSelect</h2>
+
+    <FluentSelect Label="@($"Nullable Enum: {Day1}.")"
+                  Items="Enum.GetValues<DayOfWeek>()"
+                  @bind-Value="Day1" />
+
+    <FluentSelect Label="@($"Non-Nullable Enum: {Day2}.")"
+                  Items="Enum.GetValues<DayOfWeek>()"
+                  @bind-Value="Day2" />
+
+</div>
+
+@code {
+    public DayOfWeek? Day1 { get; set; } = DayOfWeek.Tuesday;
+    public DayOfWeek Day2 { get; set; } = DayOfWeek.Tuesday;
+}

--- a/src/Core/Components/List/FluentListBase.razor.cs
+++ b/src/Core/Components/List/FluentListBase.razor.cs
@@ -202,7 +202,7 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
             return OptionSelectedComparer.Equals(item, currentAsOption);
         }
 
-        if (OptionValue is not null || typeof(TOption) == typeof(TValue))
+        if (OptionValue is not null || IsOptionTypeCompatibleWithValue())
         {
             return Equals(GetOptionValue(item), CurrentValue);
         }
@@ -218,7 +218,7 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
             return OptionValue.Invoke(item);
         }
 
-        if (typeof(TOption) == typeof(TValue))
+        if (IsOptionTypeCompatibleWithValue())
         {
             return (TValue?)(object?)item;
         }
@@ -321,5 +321,15 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
     internal InternalListContext<TValue> GetCurrentContext()
     {
         return new InternalListContext<TValue>(this);
+    }
+
+    /// <summary>
+    /// Checks whether <typeparamref name="TOption"/> is the same type as <typeparamref name="TValue"/>,
+    /// or <typeparamref name="TValue"/> is <see cref="Nullable{T}"/> of <typeparamref name="TOption"/>.
+    /// </summary>
+    private static bool IsOptionTypeCompatibleWithValue()
+    {
+        return typeof(TOption) == typeof(TValue)
+            || Nullable.GetUnderlyingType(typeof(TValue)) == typeof(TOption);
     }
 }

--- a/tests/Core/Components/List/FluentSelectTests.razor
+++ b/tests/Core/Components/List/FluentSelectTests.razor
@@ -481,6 +481,42 @@
         Assert.Contains("height: 300px", listboxStyle);
     }
 
+    [Fact]
+    public void FluentSelect_NullableEnum_InitialSelection()
+    {
+        MyDigitsEnum? value = MyDigitsEnum.Two;
+        var items = Enum.GetValues<MyDigitsEnum>();
+
+        // Arrange and Act
+        var cut = Render(@<FluentSelect Items="@items" @bind-Value="@value" />);
+        var two = cut.Find("fluent-option[value='Two']");
+
+        // Assert - The nullable enum value should be correctly selected
+        Assert.True(two.HasAttribute("selected"));
+    }
+
+    [Fact]
+    public async Task FluentSelect_NullableEnum_OnDropdownChange()
+    {
+        MyDigitsEnum? value = MyDigitsEnum.One;
+        var items = Enum.GetValues<MyDigitsEnum>();
+
+        // Arrange
+        var cut = Render(@<FluentSelect Items="@items" @bind-Value="@value" />);
+        var ids = cut.FindAll("fluent-option")
+                     .Where(i => i.GetAttribute("value") == "Three")
+                     .Select(i => i.GetAttribute("id"));
+
+        // Act
+        await cut.FindComponent<FluentSelect<MyDigitsEnum, MyDigitsEnum?>>().Instance.OnDropdownChangeHandlerAsync(new DropdownEventArgs
+        {
+            SelectedOptions = string.Join(';', ids),
+        });
+
+        // Assert
+        Assert.Equal(MyDigitsEnum.Three, value);
+    }
+
     public record Person
     {
         public int Id { get; set; }


### PR DESCRIPTION
# [dev-v5] Add nullable object support in "FluentList"

Implement functionality to handle nullable objects/enums with initial selection and dropdown change tests. 
This enhancement improves the usability of FluentSelect with nullable enum types.

Introduce a new SelectDebug page to demonstrate nullable enum support in FluentSelect. 

Before

<img width="462" height="293" alt="peek_2" src="https://github.com/user-attachments/assets/e772c1a4-b30b-42a7-a272-f0d02fad27f2" />

After

<img width="462" height="293" alt="peek_1" src="https://github.com/user-attachments/assets/ddd6d4fa-b3ad-423b-999c-a1ee415fd24e" />
