### PR TITLE
[dev-v5] Update FluentAutocomplete for multiple selections and limits

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Autocomplete/Examples/AutocompleteCustomized.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Autocomplete/Examples/AutocompleteCustomized.razor
@@ -9,6 +9,7 @@
                     Label="Select countries"
                     Placeholder="Type to search..."
                     ShowProgressIndicator="@ShowProgressIndicator"                    
+                    MaximumSelectedOptions="4"
                     MaxAutoHeight="@((MaxAutoHeight) ? "unset" : null)"
                     OnOptionsSearch="@OnSearchAsync"
                     OptionText="@(item => item.Name)"
@@ -29,7 +30,13 @@
         </FluentStack>
     </OptionTemplate>
 
-    
+    @* Maximum selected options message *@
+    <MaximumSelectedOptionsMessage>
+        <FluentText Size="TextSize.Size200" Align="TextAlign.Center" Color="Color.Error">
+            You can only select up to 4 items.
+        </FluentText>
+    </MaximumSelectedOptionsMessage>
+
     @* Content display at the top of the Popup area *@
     <HeaderContent>
         <FluentText Size="TextSize.Size200" Color="Color.Primary" Align="TextAlign.Center">

--- a/examples/Demo/FluentUI.Demo/Program.cs
+++ b/examples/Demo/FluentUI.Demo/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddFluentUIComponents(config =>
     // config.DefaultValues.For<FluentButton>().Set(p => p.Appearance, ButtonAppearance.Primary);
     // config.DefaultValues.For<FluentButton>().Set(p => p.Shape, ButtonShape.Circular);
     // config.DefaultValues.ForAny<FluentAutocomplete<object, object>>().Set(p => p.Width, "100%");
+    // config.DefaultValues.ForAny<FluentAutocomplete<object, object>>().Set(p => p.Multiple, false);
 
     // Use a custom localizer
     config.Localizer = new FluentUI.Demo.MyLocalizer();

--- a/src/Core/Components/List/FluentAutocomplete.razor
+++ b/src/Core/Components/List/FluentAutocomplete.razor
@@ -35,7 +35,7 @@
                          MessageCondition="@MessageCondition"
                          MessageIcon="@MessageIcon"
                          MessageState="@MessageState"
-                         Placeholder="@Placeholder"
+                         Placeholder="@(_internalSelectedItems.Any() ? null : Placeholder)"
                          Style="@StyleValue"
                          Name="@Name"
                          auto-complete="true"
@@ -142,16 +142,7 @@
 
             @if (IsReachedMaxItems)
             {
-                @if (MaximumSelectedOptionsMessage is null)
-                {
-                    <FluentText Size="TextSize.Size200" Align="TextAlign.Center" Color="Color.Error" Style="display: block; margin: 12px;">
-                        @Localizer[Localization.LanguageResource.AutoComplete_MaximumSelectedOptionsMessage, MaximumSelectedOptions ?? 0]
-                    </FluentText>
-                }
-                else
-                {
-                    @MaximumSelectedOptionsMessage
-                }                
+                @MaximumSelectedOptionsMessage
             }
             else
             {

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -36,11 +36,12 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
         // Default values
         Id = Identifier.NewId();
 
-        // Set default values for this component: 
-        // - if `Width` is not already set (not null),
-        // - if `Multiple` is not already set to `false` using `base(configuration)`, in the Program.cs
+        // Set default value: if `Width` is not already set (not null),
         Width ??= "160px";
-        configuration?.DefaultValues.SetInitialValues(this, [(nameof(Multiple), true)]);
+
+        // Set default value: if `Multiple` is not already set to `false` using `base(configuration)`, in the Program.cs
+        // (not used since the Multiple is overridden with a default value of true directly in this class)
+        // configuration?.DefaultValues.SetInitialValues(this, [(nameof(Multiple), true)]);
     }
 
     /// <summary />
@@ -60,6 +61,12 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
     /// </summary>
     [Parameter]
     public string? Placeholder { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the list allows multiple selections.
+    /// </summary>
+    [Parameter]
+    public override bool Multiple { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the delay, in milliseconds, before to raise the event.

--- a/src/Core/Localization/LanguageResource.resx
+++ b/src/Core/Localization/LanguageResource.resx
@@ -366,7 +366,4 @@
   <data name="Paginator_SummaryNoItems" xml:space="preserve">
     <value>No items</value>
   </data>
-  <data name="AutoComplete_MaximumSelectedOptionsMessage" xml:space="preserve">
-    <value>The maximum number of {0} selected items has been reached.</value>
-  </data>
 </root>

--- a/tests/Core/Components/List/FluentAutocompleteTests.FluentAutocomplete_Default_Items.verified.razor.html
+++ b/tests/Core/Components/List/FluentAutocompleteTests.FluentAutocomplete_Default_Items.verified.razor.html
@@ -3,7 +3,7 @@
 	<body>
 		<fluent-field id="xxx" label-position="above" style="width: 160px;">
 			<fluent-text-input style="width: 160px;" appearance="outline" autocomplete="false" id="xxx" placeholder="Select a digit" slot="input" blazor:onfocusout="2" blazor:onchange="3" blazor:ontextimmediate="4" auto-complete="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
-				<div slot="start"></div>
+				<div slot="start"><div style=""></div></div>
 				</div>
 				<div slot="end">
 					<svg style="width: 20px; fill: currentColor; cursor: pointer;" focusable="true" tabindex="0" role="button" viewBox="0 0 20 20" blazor:onkeydown="x" blazor:onclick="x" blazor:onclick:stoppropagation="" blazor:onfocus="9" blazor:elementreference="xxx">

--- a/tests/Core/Components/List/FluentAutocompleteTests.FluentAutocomplete_Label.verified.razor.html
+++ b/tests/Core/Components/List/FluentAutocompleteTests.FluentAutocomplete_Label.verified.razor.html
@@ -5,7 +5,7 @@
 			<label id="xxx" slot="label" for="xxx" required="">List of digits
 			</label>
 			<fluent-text-input style="width: 160px;" appearance="outline" autocomplete="false" id="xxx" required="" slot="input" blazor:onfocusout="2" blazor:onchange="3" blazor:ontextimmediate="4" auto-complete="true" blazor:onkeydown="x" blazor:onclick="x" blazor:elementreference="xxx">
-				<div slot="start"></div>
+				<div slot="start"><div style=""></div></div>
 				</div>
 				<div slot="end">
 					<svg style="width: 20px; fill: currentColor; cursor: pointer;" focusable="true" tabindex="0" role="button" viewBox="0 0 20 20" blazor:onkeydown="x" blazor:onclick="x" blazor:onclick:stoppropagation="" blazor:onfocus="9" blazor:elementreference="xxx">


### PR DESCRIPTION
# [dev-v5] Update FluentAutocomplete for multiple selections and limits

Enhance **FluentAutocomplete** by adding a maximum limit of selected options with an appropriate message. 
Ensure consistency in test file structures.

Update the `Placeholder` to hide it when an element is already selected

See #4717