### PR TITLE
[dev-v5] Update CSS naming and isolation guidelines in Blazor documentation

### DIFF
--- a/.github/skills/csharp-naming-conventions/SKILL.md
+++ b/.github/skills/csharp-naming-conventions/SKILL.md
@@ -78,6 +78,7 @@ Reference these guidelines when:
 - [blazor-components](rules/blazor-components.md) - Component naming, routing, and file structure
 - [blazor-structure](rules/blazor-structure.md) - Project folder organization with SOLID principles
 - [blazor-code](rules/blazor-code.md) - Methods, properties order, inject, and nullable defaults
+- [blazor-css](rules/blazor-css.md) - CSS isolation, root class and attribute selectors
 - [blazor-javascript](rules/blazor-javascript.md) - JavaScript interop and collocated JS files
 - [blazor-css](rules/blazor-css.md) - CSS isolation and ::deep pseudo-element usage
 - [blazor-performance](rules/blazor-performance.md) - Rendering, cascading parameters, and optimization

--- a/.github/skills/csharp-naming-conventions/rules/blazor-css.md
+++ b/.github/skills/csharp-naming-conventions/rules/blazor-css.md
@@ -1,8 +1,8 @@
 ---
-title: CSS Isolation in Blazor
-impact: MEDIUM
-impactDescription: Unscoped CSS causes style conflicts across components
-tags: blazor, css, isolation, deep
+title: CSS Naming and Isolation in Blazor
+impact: MEDIUM-HIGH
+impactDescription: Generic or unscoped CSS class names cause style conflicts across components and with consuming applications
+tags: blazor, css, isolation, deep, naming, attributes
 ---
 
 ## CSS Isolation
@@ -21,14 +21,62 @@ Use `::deep` [pseudo-element](https://developer.mozilla.org/docs/Web/CSS/Pseudo-
 
 > `::deep` only works for **child components**. Add a global `<div>` in your component to define the child component scope.
 
-### Naming Convention
+### CSS Class Naming Strategy
 
-**Add a common prefix to all style names** to avoid conflicts with other projects or libraries:
+Use a **root class + attribute selectors** approach rather than class-name prefixing (BEM-style) or generic class names.
+
+#### Rules
+
+1. **One namespaced root class per component** — The outermost element of each component must carry a unique, project-prefixed class (e.g. `.my-component`). All descendant styles are scoped under this root class.
+
+2. **Use HTML attributes as styling hooks** — Instead of inventing extra CSS classes for variants, states, or layout options, add semantic attributes to the rendered HTML and target them with attribute selectors. Attributes mirror component parameters, keeping markup declarative and self-documenting.
+
+3. **Never use generic, unprefixed class names** — Class names like `.grid`, `.column-header`, `.hover`, or `.column` are too broad and risk collisions with consuming applications or other libraries.
+
+#### Correct — root class + attribute selectors
 
 ```css
-.my-project-popup {
-    /* ... */
+/* Root class scopes the component */
+.my-component {
+    display: grid;
+}
+
+/* Attributes reflect component parameters */
+.my-component[spacing="3"] {
+    gap: 12px;
+}
+
+/* Child elements also targeted via attributes under the root */
+.my-component > div[role="header"] {
+    font-weight: bold;
+}
+
+.my-component > div[align="center"] {
+    text-align: center;
 }
 ```
+
+#### Wrong — generic or BEM-style class explosion
+
+```css
+/* Too generic: will collide with other libraries or user styles */
+.grid { display: grid; }
+.column-header { font-weight: bold; }
+.hover { background: highlight; }
+.col-justify-start { text-align: start; }
+
+/* BEM-style: verbose and duplicates parameter semantics */
+.my-component-spacing-3 { gap: 12px; }
+.my-component-header-bold { font-weight: bold; }
+```
+
+#### Why
+
+| Concern | Root + Attributes | Generic classes | BEM prefixing |
+|---------|:-:|:-:|:-:|
+| Collision-safe | Yes | **No** | Yes |
+| Lean markup | Yes | Yes | **No** |
+| Self-documenting | Yes | **No** | Partially |
+| Maps to component API | Yes | **No** | **No** |
 
 Reference: [Blazor CSS Isolation](https://docs.microsoft.com/en-us/aspnet/core/blazor/components/css-isolation)


### PR DESCRIPTION
[dev-v5] Update CSS naming and isolation guidelines in Blazor documentation

Enhance the Blazor documentation by updating the CSS naming and isolation guidelines. 
This change promote a more structured approach using **root classes and attribute selectors**. 