### PR TITLE
[dev-v5] Enhance Skill performance guidelines

### DIFF
--- a/.github/skills/csharp-naming-conventions/rules/blazor-performance.md
+++ b/.github/skills/csharp-naming-conventions/rules/blazor-performance.md
@@ -2,7 +2,7 @@
 title: Blazor Performance
 impact: MEDIUM-HIGH
 impactDescription: Poor rendering patterns cause slow, unresponsive Blazor applications
-tags: blazor, performance, rendering, optimization
+tags: blazor, performance, rendering, optimization, parameters
 ---
 
 ## Blazor Performance
@@ -29,6 +29,35 @@ protected override async Task OnInitializedAsync()
 ```
 
 Reference: [ASP.NET Core Blazor component lifecycle](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/lifecycle)
+
+### Use SetParametersAsync instead of OnParametersSet
+
+**RULE**: Override `SetParametersAsync` instead of `OnParametersSet` or `OnParametersSetAsync` when reacting to parameter changes.
+
+**REQUIREMENTS**:
+- DO NOT use `OnParametersSet` or `OnParametersSetAsync` to react to specific parameter changes — they fire on **every** parameter change with no way to identify which one changed.
+- USE `parameters.TryGetValue<T>(nameof(Param), out var newValue)` to inspect which parameters actually changed.
+- ALWAYS compare `newValue != CurrentValue` before executing expensive logic to avoid redundant computation.
+- ALWAYS call `await base.SetParametersAsync(parameters)` at the end.
+
+```csharp
+// ❌ Incorrect: triggers on every parameter change, cannot identify which one changed
+protected override void OnParametersSet()
+{
+    _data = ComputeExpensiveResult(Value);
+}
+
+// ✅ Correct: inspect exactly which parameters changed, skip logic if value is unchanged
+public override async Task SetParametersAsync(ParameterView parameters)
+{
+    if (parameters.TryGetValue<int>(nameof(Value), out var newValue) && newValue != Value)
+    {
+        _data = ComputeExpensiveResult(newValue);
+    }
+
+    await base.SetParametersAsync(parameters);
+}
+```
 
 ### Avoid Unnecessary Rendering
 1. Ensure child component parameters are of **primitive immutable types**.


### PR DESCRIPTION
# [dev-v5] Enhance Skill performance guidelines

Update performance guidelines to include rules for using `SetParametersAsync` to improve rendering efficiency and avoid unnecessary computations in Blazor applications. This change addresses poor rendering patterns that can lead to slow and unresponsive applications.

