### PR TITLE
[dev-v5][Select] Use max-height instead of height

### DIFF
--- a/src/Core/Components/List/FluentSelect.razor.cs
+++ b/src/Core/Components/List/FluentSelect.razor.cs
@@ -29,7 +29,7 @@ public partial class FluentSelect<TOption, TValue> : FluentListBase<TOption, TVa
 
     /// <summary />
     protected virtual string? ListStyle => new StyleBuilder()
-        .AddStyle("height", Height, when: !string.IsNullOrEmpty(Height))
+        .AddStyle("max-height", Height, when: !string.IsNullOrEmpty(Height))
         .Build();
 
     /// <summary>

--- a/tests/Core/Components/List/FluentSelectTests.FluentSelect_Width_And_Height.verified.razor.html
+++ b/tests/Core/Components/List/FluentSelectTests.FluentSelect_Width_And_Height.verified.razor.html
@@ -1,0 +1,16 @@
+<html>
+	<head></head>
+	<body>
+		<fluent-field id="xxx" label-position="above" style="width: 200px;">
+			<fluent-dropdown id="xxx" slot="input" style="width: 200px;" type="dropdown" blazor:ondropdownchange="1" blazor:onfocusout="2">
+				<fluent-listbox style="max-height: 300px;">
+					<fluent-option id="xxx"></fluent-option>
+					<fluent-option id="xxx" text="One" value="One">One</fluent-option>
+					<fluent-option id="xxx" text="Two" value="Two">Two</fluent-option>
+					<fluent-option id="xxx" text="Three" value="Three">Three</fluent-option>
+				</fluent-listbox>
+			</fluent-dropdown>
+			<fluent-text as="span" size="200" slot="message"></fluent-text>
+		</fluent-field>
+	</body>
+</html>

--- a/tests/Core/Components/List/FluentSelectTests.razor
+++ b/tests/Core/Components/List/FluentSelectTests.razor
@@ -478,7 +478,9 @@
 
         var listbox = cut.Find("fluent-listbox");
         var listboxStyle = listbox.GetAttribute("style");
-        Assert.Contains("height: 300px", listboxStyle);
+        Assert.Contains("max-height: 300px", listboxStyle);
+
+        cut.Verify();
     }
 
     [Fact]


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes the broken height in `FluentSelect` by changing the css to use `max-height` instead.

Before:

<img width="235" height="360" alt="before" src="https://github.com/user-attachments/assets/dbd32b67-f37e-45b8-af58-1694d6d927ee" />

After:

<img width="209" height="180" alt="after" src="https://github.com/user-attachments/assets/86ad6cee-4a1a-4b4b-b322-95caf6b41da3" />


### 🎫 Issues

Fixes #4729 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
