### PR TITLE
[dev-v5][Autocomplete] Fix clear selection in single mode

### DIFF
--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -443,11 +443,23 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
     private async Task ClearSelectionAsync()
     {
         _isOpen = false;
-        _internalSelectedItems.Clear();
 
-        if (SelectedItemsChanged.HasDelegate)
+        if (Multiple)
         {
-            await SelectedItemsChanged.InvokeAsync(_internalSelectedItems);
+            _internalSelectedItems.Clear();
+
+            if (SelectedItemsChanged.HasDelegate)
+            {
+                await SelectedItemsChanged.InvokeAsync(_internalSelectedItems);
+            }
+        }
+        else
+        {
+            SelectedItem = default;
+            if (SelectedItemChanged.HasDelegate)
+            {
+                await SelectedItemChanged.InvokeAsync(SelectedItem);
+            }
         }
     }
 

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -443,11 +443,10 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
     private async Task ClearSelectionAsync()
     {
         _isOpen = false;
+        _internalSelectedItems.Clear();
 
         if (Multiple)
         {
-            _internalSelectedItems.Clear();
-
             if (SelectedItemsChanged.HasDelegate)
             {
                 await SelectedItemsChanged.InvokeAsync(_internalSelectedItems);

--- a/tests/Core/Components/List/FluentAutocompleteTests.razor
+++ b/tests/Core/Components/List/FluentAutocompleteTests.razor
@@ -1032,6 +1032,28 @@
         Assert.Empty(component.SelectedItems);
     }
 
+    [Fact]
+    public void FluentAutocomplete_ClearSelection_PreDefinedValue()
+    {
+        // Arrange
+        string? selectedItem = "One";
+
+        var cut = Render(@<FluentAutocomplete TOption="string"
+                                                  TValue="string"
+                                                  Multiple="false"
+                                                  Label="Select"
+                                                  OnOptionsSearch="@OnOptionsSearch"
+                                                  @bind-SelectedItem="selectedItem" />);
+
+        Assert.NotNull(selectedItem);
+
+        var icon = cut.Find("div[slot='end'] svg[focusable='true']");
+        icon.Click();
+
+        // Verify internal stat
+        Assert.Null(selectedItem);
+    }
+
     private void OnOptionsSearch(OptionsSearchEventArgs<string> e)
     {
         e.Items = Digits.Where(i => i.StartsWith(e.Text, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR addresses the not working clearing button for `FluentAutocomplete` when it is being used in single mode and contains a pre defined value.

Previously it was only possible to clear the selection once the user has interacted with the control before. This PR fixes this and there is no longer any previous interaction required.

### 🎫 Issues

Fixes #4723 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
