### PR TITLE
[dev-v5] [AutoComplete] Fix clear selection behavior

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Autocomplete/DebugPages/AutocompleteDebug.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Autocomplete/DebugPages/AutocompleteDebug.razor
@@ -5,6 +5,7 @@
 <div style="margin: 24px;">
 
     <div>Selected items: <b>@string.Join("; ", SelectedCountries.Select(c => c.Name))</b></div>
+    <div>Selected item: <b>@SelectedCountry?.Name</b></div>
     <div>Search Text: <b>@SearchText</b></div>
 
     <FluentAutocomplete TOption="Country"
@@ -22,6 +23,7 @@
                         Multiple="@Multiple"
                         MaximumSelectedOptions="@(SetMaximumSelectedOptions ? 4 : (int?)null)"
                         @bind-Value="@SearchText"
+                        @bind-SelectedItem="@SelectedCountry"
                         @bind-SelectedItems="@SelectedCountries">
 
         @* Drop-down item template *@
@@ -76,6 +78,7 @@
                         Label="Select countries from Items"
                         Items="@Countries"
                         OptionText="@(item => item.Name)"
+                        @bind-SelectedItem="@SelectedCountry"
                         @bind-SelectedItems="@SelectedCountries" />
 
 </div>
@@ -90,6 +93,7 @@
     bool SetMaximumSelectedOptions { get; set; }
     string? SearchText { get; set; }
     IEnumerable<Country> SelectedCountries { get; set; } = [];
+    Country? SelectedCountry { get; set; }
 
     async Task OnSearchAsync(OptionsSearchEventArgs<Country> e)
     {

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -444,21 +444,16 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
     {
         _isOpen = false;
         _internalSelectedItems.Clear();
+        SelectedItem = default;
 
-        if (Multiple)
+        if (SelectedItemsChanged.HasDelegate)
         {
-            if (SelectedItemsChanged.HasDelegate)
-            {
-                await SelectedItemsChanged.InvokeAsync(_internalSelectedItems);
-            }
+            await SelectedItemsChanged.InvokeAsync(_internalSelectedItems);
         }
-        else
+
+        if (SelectedItemChanged.HasDelegate)
         {
-            SelectedItem = default;
-            if (SelectedItemChanged.HasDelegate)
-            {
-                await SelectedItemChanged.InvokeAsync(SelectedItem);
-            }
+            await SelectedItemChanged.InvokeAsync(SelectedItem);
         }
     }
 


### PR DESCRIPTION
# [dev-v5] [AutoComplete] Fix clear selection behavior

Improve the clear selection functionality in the Autocomplete component to ensure that both selected items and the selected item are properly reset. This change enhances the user experience by providing clearer feedback when selections are cleared.

Related to PR #4731

## Before

https://github.com/user-attachments/assets/8d91828d-cb86-4d7c-a3e0-746311e2d497

## After

https://github.com/user-attachments/assets/1519437b-7c91-4ff3-8794-11da179cc3ee
