### PR TITLE
[dev-v5] AutoComplete - Add OnSetValue event callback

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,10 @@
 
 - In this repository, component script changes must be made in the corresponding .ts file, not generated .js files.
 
+## Skills
+
+- When writing, reviewing, or refactoring C# / .NET / Blazor code, or when authoring unit tests with xUnit and bUnit, load and follow the [csharp-naming-conventions](skills/csharp-naming-conventions/SKILL.md) skill. Read the `SKILL.md` file with the `read_file` tool before producing code so the conventions, layout rules, and testing guidelines are applied.
+
 ## Browser Automation Guidelines
 
 - When browser automation initially fails in this workspace, retry Playwright actions instead of assuming the browser backend is unavailable.

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Autocomplete/DebugPages/AutocompleteDebug.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Autocomplete/DebugPages/AutocompleteDebug.razor
@@ -5,14 +5,13 @@
 <div style="margin: 24px;">
 
     <div>Selected items: <b>@string.Join("; ", SelectedCountries.Select(c => c.Name))</b></div>
-    <div>Search Text: <b>@SearchText</b></div>
 
     <FluentAutocomplete TOption="Country"
                         TValue="string"
                         Width="100%"
                         Label="Select countries"
                         Placeholder="Type to search..."
-                        ShowProgressIndicator="@ShowProgressIndicator"                    
+                        ShowProgressIndicator="@ShowProgressIndicator"
                         MaxAutoHeight="@((MaxAutoHeight) ? "unset" : null)"
                         OnOptionsSearch="@OnSearchAsync"
                         Items="@Countries"
@@ -26,10 +25,11 @@
 
         @* Drop-down item template *@
         <OptionTemplate>
-            <FluentStack Style="pointer-events: none;" VerticalAlignment="VerticalAlignment.Center">
+            <FluentStack Style="pointer-events: none;"
+                         VerticalAlignment="VerticalAlignment.Center">
                 <FluentAvatar Image="@context.Flag()"
-                            Name="@context.Name" 
-                            Size="AvatarSize.Size20" />
+                              Name="@context.Name"
+                              Size="AvatarSize.Size20" />
                 <FluentText Margin="@Margin.Left4">
                     @context.Name
                 </FluentText>
@@ -38,17 +38,23 @@
 
         @* Content displayed at the top of the drop-down list *@
         <HeaderContent>
-            <FluentText Size="TextSize.Size200" Color="Color.Primary" Align="TextAlign.Center">
+            <FluentText Size="TextSize.Size200"
+                        Color="Color.Primary"
+                        Align="TextAlign.Center">
                 Suggested contacts
             </FluentText>
-            <FluentProgressBar Thickness="ProgressThickness.Large" Visible="@context.InProgress" />
+            <FluentProgressBar Thickness="ProgressThickness.Large"
+                               Visible="@context.InProgress" />
         </HeaderContent>
 
         @* Content displayed at the bottom of the drop-down list *@
         <FooterContent>
             @if (!context.Items.Any())
             {
-                <FluentText Size="TextSize.Size200" Align="TextAlign.Center" Color="Color.Error" Style="width: 100%;">
+                <FluentText Size="TextSize.Size200"
+                            Align="TextAlign.Center"
+                            Color="Color.Error"
+                            Style="width: 100%;">
                     No results found
                 </FluentText>
             }
@@ -57,18 +63,25 @@
     </FluentAutocomplete>
 
     <FluentStack Orientation="Orientation.Vertical">
-        <FluentSwitch @bind-Value="@ShowProgressIndicator" Label="Show progress indicator" />
-        <FluentSwitch @bind-Value="@MaxAutoHeight" Label="Auto height" />
-        <FluentSwitch @bind-Value="@MaxSelectedWidth" Label="Set a max selected width (40px)" />
-        <FluentSwitch @bind-Value="@ShowDismiss" Label="Show search or dismiss button" />
-        <FluentSwitch @bind-Value="@Multiple" Label="Multiple selection" />
-        <FluentSwitch @bind-Value="@SetMaximumSelectedOptions" Label="Set MaximumSelectedOptions to 4" />
+        <FluentSwitch @bind-Value="@ShowProgressIndicator"
+                      Label="Show progress indicator" />
+        <FluentSwitch @bind-Value="@MaxAutoHeight"
+                      Label="Auto height" />
+        <FluentSwitch @bind-Value="@MaxSelectedWidth"
+                      Label="Set a max selected width (40px)" />
+        <FluentSwitch @bind-Value="@ShowDismiss"
+                      Label="Show search or dismiss button" />
+        <FluentSwitch @bind-Value="@Multiple"
+                      Label="Multiple selection" />
+        <FluentSwitch @bind-Value="@SetMaximumSelectedOptions"
+                      Label="Set MaximumSelectedOptions to 4" />
         <FluentButton OnClick="@SetSelectedCountriesAsync">
             Set SelectedCountries to [be, fr]
         </FluentButton>
     </FluentStack>
 
 
+    @* Set the Items property *@
     <FluentAutocomplete TOption="Country"
                         TValue="string"
                         Width="100%"
@@ -77,6 +90,22 @@
                         Items="@Countries"
                         OptionText="@(item => item.Name)"
                         @bind-SelectedItems="@SelectedCountries" />
+
+    @* Bind to an Int32 *@
+    @* User {int Id, string Name} *@
+    <FluentAutocomplete TOption="User"
+                        TValue="int?"
+                        Width="100%"
+                        Label="@($"Bind to an Int32 (SelectedUserId: {SelectedUserId})")"
+                        Multiple="false"
+                        OnOptionsSearch="@(args => { args.Items = User.GetUsers().Where(u => u.Name.StartsWith(args.Text, StringComparison.OrdinalIgnoreCase)); return Task.CompletedTask; })"
+                        OnSetValue="@(args => args.Item = User.GetUsers().FirstOrDefault(u => u.Id == args.Value))"
+                        OptionText="@(item => item?.Name)"
+                        OptionValue="@(item => item?.Id)"
+                        @bind-Value="@SelectedUserId" />
+    <FluentButton OnClick="@(e => SelectedUserId = 3)">
+        Set SelectedUserId to 3
+    </FluentButton>
 
 </div>
 
@@ -90,6 +119,7 @@
     bool SetMaximumSelectedOptions { get; set; }
     string? SearchText { get; set; }
     IEnumerable<Country> SelectedCountries { get; set; } = [];
+    int? SelectedUserId { get; set; }
 
     async Task OnSearchAsync(OptionsSearchEventArgs<Country> e)
     {
@@ -106,5 +136,37 @@
     {
         SelectedCountries = Countries.Where(i => i.Code == "be" || i.Code == "fr");
         await Task.CompletedTask;
+    }
+
+    class User : IEqualityComparer<User>
+    {
+        public static IEnumerable<User> GetUsers() => new List<User>
+        {
+            new User { Id = 1, Name = "Alice" },
+            new User { Id = 2, Name = "Bob" },
+            new User { Id = 3, Name = "Charlie" },
+            new User { Id = 4, Name = "David" },
+            new User { Id = 5, Name = "Eve" }
+        };
+
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+
+        public bool Equals(User? x, User? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            return x.Id == y.Id;
+        }
+
+        public int GetHashCode(User obj) => obj.Id.GetHashCode();
     }
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Autocomplete/FluentAutocomplete.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/List/Autocomplete/FluentAutocomplete.md
@@ -61,6 +61,8 @@ the component cannot match them to already-selected items by **reference**.
 Use the `OptionSelectedComparer` parameter to provide a custom `IEqualityComparer<TOption>` that compares items by a unique key (such as an ID)
 instead of by reference. Without this, previously selected items may not appear as checked in the refreshed list.
 
+If your object implements `IEqualityComparer<T>`, you can omit the `OptionSelectedComparer` parameter, as the component will automatically use the object's built-in equality logic to match selected items.
+
 {{ AutocompleteComparer }}
 
 ## API FluentAutocomplete

--- a/src/Core/Components/List/FluentAutocomplete.razor.cs
+++ b/src/Core/Components/List/FluentAutocomplete.razor.cs
@@ -81,6 +81,14 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
     [Parameter]
     public EventCallback<OptionsSearchEventArgs<TOption>> OnOptionsSearch { get; set; }
 
+    /// <summary>
+    /// Gets or sets an event callback that is raised when the component needs to resolve the item corresponding to a given value,
+    /// for example when Value is set from outside the component.
+    /// The handler should set the Item property of the event args to the resolved item for the given value.
+    /// </summary>
+    [Parameter]
+    public EventCallback<SetValueEventArgs<TOption, TValue>> OnSetValue { get; set; }
+
     /// <inheritdoc cref="FluentListBase{TOption, TValue}.SelectedItems" />
     public override IEnumerable<TOption> SelectedItems
     {
@@ -197,7 +205,7 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
     }
 
     /// <summary />
-    public override Task SetParametersAsync(ParameterView parameters)
+    public override async Task SetParametersAsync(ParameterView parameters)
     {
         // Check if SelectedItem is being supplied and has changed
         if (parameters.TryGetValue<TOption?>(nameof(SelectedItem), out var newSelectedItem))
@@ -213,7 +221,36 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
             }
         }
 
-        return base.SetParametersAsync(parameters);
+        // Check if Value is being supplied and has changed (e.g. set by the developer during initialization).
+        // If so, resolve the associated option via the OnSetValue callback and synchronize the selection.
+        if (parameters.TryGetValue<TValue?>(nameof(Value), out var newValue))
+        {
+            var valueComparer = EqualityComparer<TValue>.Default;
+            var currentValue = GetOptionValue(_internalSelectedItem);
+
+            if (!valueComparer.Equals(newValue, currentValue) && OnSetValue.HasDelegate)
+            {
+                var args = new SetValueEventArgs<TOption, TValue>
+                {
+                    Value = newValue,
+                };
+
+                await OnSetValue.InvokeAsync(args);
+
+                if (args.Item is not null)
+                {
+                    _internalSelectedItems = [args.Item];
+                    SelectedItem = args.Item;
+                }
+                else
+                {
+                    _internalSelectedItems = [];
+                    SelectedItem = default;
+                }
+            }
+        }
+
+        await base.SetParametersAsync(parameters);
     }
 
     /// <summary>
@@ -343,13 +380,6 @@ public partial class FluentAutocomplete<TOption, TValue> : FluentListBase<TOptio
     /// <returns></returns>
     internal async Task DisplayFilteredOptionsAsync(bool showWhenInputIsEmpty)
     {
-        // Raise the ValueChanged event to notify the parent component.
-        if (ValueChanged.HasDelegate)
-        {
-            var value = _textInput ?? string.Empty;
-            await ValueChanged.InvokeAsync((TValue)(object)value);
-        }
-
         // If the input is empty, we don't show any options in the listbox, and we close it if it was open
         if (!showWhenInputIsEmpty && string.IsNullOrEmpty(_textInput))
         {

--- a/src/Core/Components/List/FluentListBase.razor.cs
+++ b/src/Core/Components/List/FluentListBase.razor.cs
@@ -22,6 +22,12 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DropdownEventArgs))]
     protected FluentListBase(LibraryConfiguration configuration) : base(configuration)
     {
+        // If TOption implements IEqualityComparer<TOption> and exposes a public parameterless
+        // constructor, use a new instance of TOption as the default OptionSelectedComparer.
+        if (OptionSelectedComparer is null && _defaultOptionSelectedComparer.Value is { } defaultComparer)
+        {
+            OptionSelectedComparer = defaultComparer;
+        }
     }
 
     /// <inheritdoc />
@@ -331,5 +337,34 @@ public abstract partial class FluentListBase<TOption, TValue> : FluentInputBase<
     {
         return typeof(TOption) == typeof(TValue)
             || Nullable.GetUnderlyingType(typeof(TValue)) == typeof(TOption);
+    }
+
+    // Cached default comparer (computed once per closed generic type).
+    private static readonly Lazy<IEqualityComparer<TOption>?> _defaultOptionSelectedComparer = new(CreateDefaultOptionSelectedComparer);
+
+    [UnconditionalSuppressMessage("Trimming", "IL2090:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "Best-effort default comparer detection; safely returns null when the constructor is trimmed.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2087:'type' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "Best-effort default comparer detection; falls back to null when the constructor is trimmed.")]
+    private static IEqualityComparer<TOption>? CreateDefaultOptionSelectedComparer()
+    {
+        var optionType = typeof(TOption);
+
+        if (!typeof(IEqualityComparer<TOption>).IsAssignableFrom(optionType))
+        {
+            return null;
+        }
+
+        if (optionType.GetConstructor(Type.EmptyTypes) is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return Activator.CreateInstance(optionType) as IEqualityComparer<TOption>;
+        }
+        catch (MissingMethodException)
+        {
+            return null;
+        }
     }
 }

--- a/src/Core/Components/List/SetValueEventArgs.cs
+++ b/src/Core/Components/List/SetValueEventArgs.cs
@@ -1,0 +1,23 @@
+// ------------------------------------------------------------------------
+// This file is licensed to you under the MIT License.
+// ------------------------------------------------------------------------
+
+namespace Microsoft.FluentUI.AspNetCore.Components;
+
+/// <summary>
+/// <see cref="FluentAutocomplete{TOption, TValue}"/> uses this event to return the resolved item for a given value when Value is set.
+/// </summary>
+/// <typeparam name="TOption"></typeparam>
+/// <typeparam name="TValue"></typeparam>
+public class SetValueEventArgs<TOption, TValue>
+{
+    /// <summary>
+    /// Gets the value to resolve. The handler should set Item to the resolved item for this value.
+    /// </summary>
+    public TValue? Value { get; init; }
+    
+    /// <summary>
+    /// Gets or sets the resolved item for the given Value.
+    /// </summary>
+    public TOption? Item { get; set; }
+}

--- a/tests/Core/Components/List/FluentAutocompleteTests.razor
+++ b/tests/Core/Components/List/FluentAutocompleteTests.razor
@@ -1054,9 +1054,112 @@
         Assert.Null(selectedItem);
     }
 
+    [Fact]
+    public async Task FluentAutocomplete_OnSetValue_ResolvesItemFromValue()
+    {
+        // Arrange - Render without an initial Value, OnSetValue resolves the matching digit
+        SetValueEventArgs<string, string>? receivedArgs = null;
+
+        var cut = Render(@<FluentAutocomplete Id="my-list"
+                                TOption="string"
+                                TValue="string"
+                                Multiple="false"
+                                Items="@Digits"
+                                OnSetValue="@(args => { receivedArgs = args; args.Item = Digits.FirstOrDefault(d => d == args.Value); })" />);
+
+        // Act - Set Value externally to "Three" → triggers OnSetValue
+        var component = cut.FindComponent<FluentAutocomplete<string, string>>().Instance;
+        var newParameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            { nameof(FluentAutocomplete<string, string>.Value), "Three" }
+        });
+        await cut.InvokeAsync(() => component.SetParametersAsync(newParameters));
+
+        // Assert - OnSetValue was invoked with the new Value
+        Assert.NotNull(receivedArgs);
+        Assert.Equal("Three", receivedArgs!.Value);
+
+        // Assert - The resolved item is selected and displayed as a badge
+        Assert.Equal("Three", component.SelectedItem);
+        Assert.Single(component.SelectedItems);
+
+        var badge = cut.Find("span.fluent-badge[alone]");
+        Assert.Equal("Three", badge.GetAttribute("title"));
+    }
+
+    [Fact]
+    public async Task FluentAutocomplete_OnSetValue_UnresolvedValueClearsSelection()
+    {
+        // Arrange - Pre-select "Three", then set Value to something OnSetValue cannot resolve
+        var cut = Render(@<FluentAutocomplete Id="my-list"
+                                TOption="string"
+                                TValue="string"
+                                Multiple="false"
+                                Items="@Digits"
+                                SelectedItem="@("Three")"
+                                OnSetValue="@(args => { args.Item = Digits.FirstOrDefault(d => d == args.Value); })" />);
+
+        // Verify initial state
+        Assert.Equal("Three", cut.Find("span.fluent-badge[alone]").GetAttribute("title"));
+
+        // Act - Set Value to a string that does not match any digit
+        var component = cut.FindComponent<FluentAutocomplete<string, string>>().Instance;
+        var newParameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            { nameof(FluentAutocomplete<string, string>.Value), "Unknown" }
+        });
+        await cut.InvokeAsync(() => component.SetParametersAsync(newParameters));
+
+        // Assert - Selection is cleared because OnSetValue returned a null Item
+        Assert.Null(component.SelectedItem);
+        Assert.Empty(component.SelectedItems);
+        Assert.Empty(cut.FindAll("span.fluent-badge"));
+    }
+
     private void OnOptionsSearch(OptionsSearchEventArgs<string> e)
     {
         e.Items = Digits.Where(i => i.StartsWith(e.Text, StringComparison.OrdinalIgnoreCase))
                         .OrderBy(i => i);
+    }
+
+    [Fact]
+    public void FluentAutocomplete_DefaultOptionSelectedComparer_UsesTOptionAsComparer()
+    {
+        // Arrange & Act - TOption (Person) implements IEqualityComparer<Person> and has a public parameterless ctor
+        var cut = Render(@<FluentAutocomplete TOption="Person" TValue="int" Id="my-list" />);
+
+        // Assert - The default OptionSelectedComparer is automatically set to a new Person instance
+        var component = cut.FindComponent<FluentAutocomplete<Person, int>>().Instance;
+        Assert.NotNull(component.OptionSelectedComparer);
+        Assert.IsType<Person>(component.OptionSelectedComparer);
+
+        // Verify it actually compares Persons by Id
+        var p1 = new Person { Id = 1, Name = "Alice" };
+        var p2 = new Person { Id = 1, Name = "Alice (renamed)" };
+        var p3 = new Person { Id = 2, Name = "Bob" };
+        Assert.True(component.OptionSelectedComparer!.Equals(p1, p2));
+        Assert.False(component.OptionSelectedComparer!.Equals(p1, p3));
+    }
+
+    [Fact]
+    public void FluentAutocomplete_DefaultOptionSelectedComparer_NullWhenTOptionDoesNotImplementComparer()
+    {
+        // Arrange & Act - string does NOT implement IEqualityComparer<string>
+        var cut = Render(@<FluentAutocomplete TOption="string" TValue="string" Id="my-list" />);
+
+        // Assert - No default comparer is set
+        var component = cut.FindComponent<FluentAutocomplete<string, string>>().Instance;
+        Assert.Null(component.OptionSelectedComparer);
+    }
+
+    public class Person : IEqualityComparer<Person>
+    {
+        public int Id { get; set; }
+
+        public string? Name { get; set; }
+
+        public bool Equals(Person? x, Person? y) => x?.Id == y?.Id;
+
+        public int GetHashCode(Person obj) => obj.Id.GetHashCode();
     }
 }

--- a/tests/Core/Components/List/FluentAutocompleteTests.razor
+++ b/tests/Core/Components/List/FluentAutocompleteTests.razor
@@ -671,14 +671,14 @@
            .TriggerEvent("ontextimmediate", new ChangeEventArgs() { Value = "F" });
 
         // Assert - ValueChanged should have been raised with the typed text "F"
-        Assert.Contains("F", valueChangedHistory);
+        Assert.Empty(valueChangedHistory);
 
         // Act - Type "Fo" to trigger again
         cut.Find("fluent-text-input")
            .TriggerEvent("ontextimmediate", new ChangeEventArgs() { Value = "Fo" });
 
         // Assert - ValueChanged should have been raised with "Fo"
-        Assert.Contains("Fo", valueChangedHistory);
+        Assert.Empty(valueChangedHistory);
     }
 
     [Fact]


### PR DESCRIPTION
# [dev-v5] AutoComplete - Add OnSetValue event callback

Introduce an `OnSetValue` event callback to the `FluentAutocomplete` component, allowing for better handling of value changes. Implement a `SetValueEventArgs` class to facilitate this. 

This fix #4724

## Demo (from `AutocompleteDebug.razor`)

```razor
<FluentAutocomplete TOption="User"
                    TValue="int?"
                    Multiple="false"
                    OnOptionsSearch="@(args => { args.Items = User.GetUsers().Where(u => u.Name.StartsWith(args.Text, StringComparison.OrdinalIgnoreCase)); return Task.CompletedTask; })"
                    OptionText="@(item => item?.Name)"
                    // 👇  New parameter
                    OnSetValue="@(args => args.Item = User.GetUsers().FirstOrDefault(u => u.Id == args.Value))"   
                    OptionValue="@(item => item?.Id)"   // 👈 Allow two-way binding
                    @bind-Value="@SelectedUserId" />
@code
{
    int? SelectedUserId { get; set; }
}
```

https://github.com/user-attachments/assets/9f7a0ddf-0fbb-4001-ad2b-6e41f8f1789f



## Unit Tests

Add tests to ensure the correct behavior of the new functionality and verify that the `ValueChanged` history remains empty for immediate input changes.