### PR TITLE
[dev-v5] [Autocomplete] Autocomplete scrolls hovered option into view

### DIFF
--- a/src/Core.Scripts/src/Components/List/FluentAutocomplete.ts
+++ b/src/Core.Scripts/src/Components/List/FluentAutocomplete.ts
@@ -171,6 +171,7 @@ export namespace Microsoft.FluentUI.Blazor.Components.Autocomplete {
       this.clearAllHovers();
       options[index].setAttribute('hovered', '');
       options[index].tabIndex = 0;
+      options[index].scrollIntoView({ block: 'nearest', inline: 'nearest' });
     }
 
     /**


### PR DESCRIPTION
# [dev-v5] [Autocomplete] Autocomplete scrolls hovered option into view

Enhance keyboard navigation by ensuring the hovered option in the autocomplete list scrolls into view, improving user experience during selection.


https://github.com/user-attachments/assets/31f9d78e-e27b-47ac-9aa5-c91755907d8f

Fix #4734
