### PR TITLE
[dev-v5] Fix DisposeAsync to handle InvalidOperationException during disposal

### DIFF
--- a/src/Core/Components/Base/FluentInputBase.cs
+++ b/src/Core/Components/Base/FluentInputBase.cs
@@ -231,7 +231,8 @@ public abstract partial class FluentInputBase<TValue> : InputBase<TValue>, IFlue
                 await DisposeAsync(_jsModule.ObjectReference);
             }
             catch (Exception ex) when (ex is JSDisconnectedException ||
-                                       ex is OperationCanceledException)
+                                       ex is OperationCanceledException ||
+                                       ex is InvalidOperationException)
             {
                 // The JSRuntime side may routinely be gone already if the reason we're disposing is that
                 // the client disconnected. This is not an error.


### PR DESCRIPTION
# [dev-v5] Fix DisposeAsync to handle InvalidOperationException during disposal

Improved error handling in `DisposeAsync` method to include `InvalidOperationException`.
This change ensures that disposal can proceed smoothly even when this specific exception occurs, enhancing the robustness of the disposal process.

Fixes #4739