### PR TITLE
[dev-v5][Nav] Fix using WithColor() with icons in Nav

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Nav/Examples/NavDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Nav/Examples/NavDefault.razor
@@ -11,7 +11,7 @@
                Density="@Density">
 
         <!-- Navigation Items -->
-        <FluentNavItem Href="/NavX" IconRest="@((new Icons.Regular.Size20.Board().WithColor(Color.Error)))" IconActive="@((new Icons.Filled.Size20.Board().WithColor(Color.Success)))">
+        <FluentNavItem Href="/Nav" IconRest="@((new Icons.Regular.Size20.Board().WithColor(Color.Error)))" IconActive="@((new Icons.Filled.Size20.Board().WithColor(Color.Success)))">
             Dashboard
         </FluentNavItem>
         <FluentNavItem OnClick="@ShowInformationAsync" IconRest="@((new Icons.Regular.Size20.MegaphoneLoud()))" IconActive="@((new Icons.Filled.Size20.MegaphoneLoud()))">
@@ -29,7 +29,7 @@
         <FluentNavSectionHeader Title="Employee Management" />
 
         <FluentNavCategory Title="Job Postings" IconRest="@((new Icons.Regular.Size20.NotePin().WithColor(Color.Error)))" IconActive="@((new Icons.Filled.Size20.NotePin().WithColor(Color.Success)))">
-            <FluentNavItem Href="/Nav" OnClick="@ShowInformationAsync">Openings</FluentNavItem>
+            <FluentNavItem OnClick="@ShowInformationAsync">Openings</FluentNavItem>
             <FluentNavItem OnClick="@ShowInformationAsync">Submissions</FluentNavItem>
         </FluentNavCategory>
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Nav/Examples/NavDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Nav/Examples/NavDefault.razor
@@ -28,8 +28,8 @@
         <!-- Employee Management -->
         <FluentNavSectionHeader Title="Employee Management" />
 
-        <FluentNavCategory Title="Job Postings" IconRest="@((new Icons.Regular.Size20.NotePin()))" IconActive="@((new Icons.Filled.Size20.NotePin()))">
-            <FluentNavItem OnClick="@ShowInformationAsync">Openings</FluentNavItem>
+        <FluentNavCategory Title="Job Postings" IconRest="@((new Icons.Regular.Size20.NotePin().WithColor(Color.Error)))" IconActive="@((new Icons.Filled.Size20.NotePin().WithColor(Color.Success)))">
+            <FluentNavItem Href="/Nav" OnClick="@ShowInformationAsync">Openings</FluentNavItem>
             <FluentNavItem OnClick="@ShowInformationAsync">Submissions</FluentNavItem>
         </FluentNavCategory>
 

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Nav/Examples/NavDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Nav/Examples/NavDefault.razor
@@ -11,7 +11,7 @@
                Density="@Density">
 
         <!-- Navigation Items -->
-        <FluentNavItem Href="/Nav" IconRest="@((new Icons.Regular.Size20.Board()))" IconActive="@((new Icons.Filled.Size20.Board()))">
+        <FluentNavItem Href="/NavX" IconRest="@((new Icons.Regular.Size20.Board().WithColor(Color.Error)))" IconActive="@((new Icons.Filled.Size20.Board().WithColor(Color.Success)))">
             Dashboard
         </FluentNavItem>
         <FluentNavItem OnClick="@ShowInformationAsync" IconRest="@((new Icons.Regular.Size20.MegaphoneLoud()))" IconActive="@((new Icons.Filled.Size20.MegaphoneLoud()))">

--- a/src/Core/Components/Nav/FluentNavCategory.razor
+++ b/src/Core/Components/Nav/FluentNavCategory.razor
@@ -13,7 +13,10 @@
 			@attributes="@AdditionalAttributes">
 		@if (Owner.UseIcons && IconRest is not null)
 		{
-			<FluentIcon Value="@(_isActive ? IconActive ?? IconRest : IconRest)" Class="icon" Color="@(_isActive ? Color.Primary : Color.Default)" />
+            var customColor = _isActive ? (IconActive?.Color ?? IconRest.Color) : IconRest.Color;
+			<FluentIcon Value="@(_isActive ? IconActive ?? IconRest : IconRest)" Class="icon" Color="@(_isActive
+                ? (customColor != null ? Color.Custom : Color.Primary)
+                : (customColor != null ? Color.Custom : Color.Default))" CustomColor="@(customColor)" />
 		}
 		@Title
 		<span aria-hidden="true" class="@( "expand-icon" + (Expanded ? " expanded" : "") + (_hasBeenManuallyCollapsed ? " user-interacted" : "") )">

--- a/src/Core/Components/Nav/FluentNavItem.razor.cs
+++ b/src/Core/Components/Nav/FluentNavItem.razor.cs
@@ -187,10 +187,18 @@ public partial class FluentNavItem : FluentNavBase
         {
             if (IconRest is not null)
             {
+                var customColor = _isActive ? (IconActive?.Color ?? IconRest.Color) : IconRest.Color;
                 builder.OpenComponent<FluentIcon<Icon>>(0);
                 builder.AddAttribute(1, "Value", _isActive ? IconActive ?? IconRest : IconRest);
                 builder.AddAttribute(2, "Class", "icon");
-                builder.AddAttribute(3, "Color", _isActive ? Color.Primary : Color.Default);
+                builder.AddAttribute(3, "Color", _isActive
+                    ? (customColor != null ? Color.Custom : Color.Primary)
+                    : (customColor != null ? Color.Custom : Color.Default));
+                if (customColor != null)
+                {
+                    builder.AddAttribute(4, "CustomColor", customColor);
+                }
+
                 builder.CloseComponent();
             }
             else

--- a/tests/Core/Components/Nav/FluentNavCategoryTests.razor
+++ b/tests/Core/Components/Nav/FluentNavCategoryTests.razor
@@ -145,6 +145,129 @@
         Assert.Contains("fluent-navsubitem", cut.Markup);
     }
 
+    // Icon WithColor tests
+    // Each test creates its own icon instance to avoid mutating the shared Samples.Icons statics.
+
+    [Fact]
+    public void FluentNavCategory_IconRest_WithColor_HexString_Renders_CustomColor_When_Inactive()
+    {
+        // Arrange
+        var icon = Samples.Icons.NewInfo().WithColor("#F97316");
+
+        // Act
+        var cut = Render(@<FluentNav>
+            <FluentNavCategory Title="Test Category" IconRest="@icon">
+                <FluentNavItem>Sub Item</FluentNavItem>
+            </FluentNavCategory>
+        </FluentNav>);
+
+        // Assert
+        Assert.Contains("fill: #F97316", cut.Markup);
+    }
+
+    [Fact]
+    public void FluentNavCategory_IconRest_WithColor_Enum_Renders_CustomColor_When_Inactive()
+    {
+        // Arrange
+        var icon = Samples.Icons.NewInfo().WithColor(Color.Error);
+
+        // Act
+        var cut = Render(@<FluentNav>
+            <FluentNavCategory Title="Test Category" IconRest="@icon">
+                <FluentNavItem>Sub Item</FluentNavItem>
+            </FluentNavCategory>
+        </FluentNav>);
+
+        // Assert
+        Assert.Contains("fill: var(--error)", cut.Markup);
+    }
+
+    [Fact]
+    public async Task FluentNavCategory_Active_IconRest_WithColor_NoIconActive_Uses_IconRest_Color()
+    {
+        // Arrange
+        var navManager = Services.GetRequiredService<NavigationManager>();
+        navManager.NavigateTo("/test-page");
+        var icon = Samples.Icons.NewInfo().WithColor("#F97316");
+
+        // Act
+        var cut = Render(@<FluentNav>
+            <FluentNavCategory Title="Test Category" Expanded="true" IconRest="@icon">
+                <FluentNavItem Href="/test-page">Active Sub Item</FluentNavItem>
+            </FluentNavCategory>
+        </FluentNav>);
+
+        var category = cut.FindComponent<FluentNavCategory>();
+        await category.Instance.ToggleExpandedAsync();
+
+        // Assert
+        Assert.Contains("fill: #F97316", cut.Markup);
+    }
+
+    [Fact]
+    public async Task FluentNavCategory_Active_IconActive_WithColor_Overrides_IconRest_Color()
+    {
+        // Arrange
+        var navManager = Services.GetRequiredService<NavigationManager>();
+        navManager.NavigateTo("/test-page");
+        var iconRest = Samples.Icons.NewInfo().WithColor("#F97316");
+        var iconActive = Samples.Icons.NewWarning().WithColor("#22C55E");
+
+        // Act
+        var cut = Render(@<FluentNav>
+            <FluentNavCategory Title="Test Category" Expanded="true" IconRest="@iconRest" IconActive="@iconActive">
+                <FluentNavItem Href="/test-page">Active Sub Item</FluentNavItem>
+            </FluentNavCategory>
+        </FluentNav>);
+
+        var category = cut.FindComponent<FluentNavCategory>();
+        await category.Instance.ToggleExpandedAsync();
+
+        // Assert
+        Assert.Contains("fill: #22C55E", cut.Markup);
+        Assert.DoesNotContain("fill: #F97316", cut.Markup);
+    }
+
+    [Fact]
+    public async Task FluentNavCategory_Active_IconActive_WithoutColor_Falls_Back_To_Primary()
+    {
+        // Arrange
+        var navManager = Services.GetRequiredService<NavigationManager>();
+        navManager.NavigateTo("/test-page");
+        var iconRest = Samples.Icons.NewInfo();
+        var iconActive = Samples.Icons.NewWarning();
+
+        // Act
+        var cut = Render(@<FluentNav>
+            <FluentNavCategory Title="Test Category" Expanded="true" IconRest="@iconRest" IconActive="@iconActive">
+                <FluentNavItem Href="/test-page">Active Sub Item</FluentNavItem>
+            </FluentNavCategory>
+        </FluentNav>);
+
+        var category = cut.FindComponent<FluentNavCategory>();
+        await category.Instance.ToggleExpandedAsync();
+
+        // Assert
+        Assert.Contains("fill: var(--colorBrandForeground1)", cut.Markup);
+    }
+
+    [Fact]
+    public void FluentNavCategory_Inactive_IconRest_Without_WithColor_Uses_Default_Color()
+    {
+        // Arrange
+        var icon = Samples.Icons.NewInfo();
+
+        // Act
+        var cut = Render(@<FluentNav>
+            <FluentNavCategory Title="Test Category" IconRest="@icon">
+                <FluentNavItem>Sub Item</FluentNavItem>
+            </FluentNavCategory>
+        </FluentNav>);
+
+        // Assert
+        Assert.Contains("fill: var(--colorNeutralForeground1)", cut.Markup);
+    }
+
 	[Fact]
 	public async Task FluentNavCategory_DisposeAsync()
 	{

--- a/tests/Core/Components/Nav/FluentNavItemTests.razor
+++ b/tests/Core/Components/Nav/FluentNavItemTests.razor
@@ -243,9 +243,11 @@
 		// Arrange
 		var navMan = Services.GetRequiredService<NavigationManager>();
 		navMan.NavigateTo("https://localhost/test", true);
+        
+        var icon = Samples.Icons.Info;
 
 		var cut = Render(@<FluentNav>
-				<FluentNavItem Id="link" IconRest="@Samples.Icons.Info" Href="https://localhost/test">Test Item</FluentNavItem>
+				<FluentNavItem Id="link" IconRest="@icon" Href="https://localhost/test">Test Item</FluentNavItem>
 			</FluentNav>);
 
 		// Assert
@@ -709,6 +711,112 @@
 
 		// Assert - OnItemClick should NOT have been invoked
 		Assert.Null(clickedItem);
+	}
+
+	// Icon WithColor tests
+	// Each test creates its own icon instance to avoid mutating the shared Samples.Icons statics.
+
+	[Fact]
+	public void FluentNavItem_IconRest_WithColor_HexString_Renders_CustomColor_When_Inactive()
+	{
+		// Arrange
+		var icon = Samples.Icons.NewInfo().WithColor("#F97316");
+
+		// Act
+		var cut = Render(@<FluentNav>
+			<FluentNavItem IconRest="@icon">Test Item</FluentNavItem>
+		</FluentNav>);
+
+		// Assert - inactive item: custom hex color on IconRest is rendered as a fill value
+		Assert.Contains("fill: #F97316", cut.Markup);
+	}
+
+	[Fact]
+	public void FluentNavItem_IconRest_WithColor_Enum_Renders_CustomColor_When_Inactive()
+	{
+		// Arrange - Color.Error maps to var(--error) per its [Description] attribute
+		var icon = Samples.Icons.NewInfo().WithColor(Color.Error);
+
+		// Act
+		var cut = Render(@<FluentNav>
+			<FluentNavItem IconRest="@icon">Test Item</FluentNavItem>
+		</FluentNav>);
+
+		// Assert - inactive item: named color enum value is rendered as its CSS variable
+		Assert.Contains("fill: var(--error)", cut.Markup);
+	}
+
+	[Fact]
+	public void FluentNavItem_Active_IconRest_WithColor_NoIconActive_Uses_IconRest_Color()
+	{
+		// Arrange
+		var navMan = Services.GetRequiredService<NavigationManager>();
+		navMan.NavigateTo("https://localhost/test", true);
+		var icon = Samples.Icons.NewInfo().WithColor("#F97316");
+
+		// Act
+		var cut = Render(@<FluentNav>
+			<FluentNavItem Href="https://localhost/test" IconRest="@icon">Test Item</FluentNavItem>
+		</FluentNav>);
+
+		// Assert - active item with no IconActive: IconRest.Color is used as the custom color
+		Assert.Contains("fill: #F97316", cut.Markup);
+	}
+
+	[Fact]
+	public void FluentNavItem_Active_IconActive_WithColor_Overrides_IconRest_Color()
+	{
+		// Arrange
+		var navMan = Services.GetRequiredService<NavigationManager>();
+		navMan.NavigateTo("https://localhost/test", true);
+		var iconRest = Samples.Icons.NewInfo().WithColor("#F97316");
+		var iconActive = Samples.Icons.NewWarning().WithColor("#22C55E");
+
+		// Act
+		var cut = Render(@<FluentNav>
+			<FluentNavItem Href="https://localhost/test"
+						   IconRest="@iconRest"
+						   IconActive="@iconActive">Test Item</FluentNavItem>
+		</FluentNav>);
+
+		// Assert - active item: IconActive.Color takes precedence over IconRest.Color
+		Assert.Contains("fill: #22C55E", cut.Markup);
+		Assert.DoesNotContain("fill: #F97316", cut.Markup);
+	}
+
+	[Fact]
+	public void FluentNavItem_Active_IconActive_WithoutColor_Falls_Back_To_Primary()
+	{
+		// Arrange
+		var navMan = Services.GetRequiredService<NavigationManager>();
+		navMan.NavigateTo("https://localhost/test", true);
+		var iconRest = Samples.Icons.NewInfo();
+		var iconActive = Samples.Icons.NewWarning();
+
+		// Act — neither icon has WithColor, so customColor is null → Color.Primary is used
+		var cut = Render(@<FluentNav>
+			<FluentNavItem Href="https://localhost/test"
+						   IconRest="@iconRest"
+						   IconActive="@iconActive">Test Item</FluentNavItem>
+		</FluentNav>);
+
+		// Assert - active item, no custom color on either icon: Color.Primary CSS variable applied
+		Assert.Contains("fill: var(--colorBrandForeground1)", cut.Markup);
+	}
+
+	[Fact]
+	public void FluentNavItem_Inactive_IconRest_Without_WithColor_Uses_Default_Color()
+	{
+		// Arrange
+		var icon = Samples.Icons.NewInfo();
+
+		// Act — no WithColor call: customColor is null → Color.Default
+		var cut = Render(@<FluentNav>
+			<FluentNavItem IconRest="@icon">Test Item</FluentNavItem>
+		</FluentNav>);
+
+		// Assert - inactive item, no custom color: Color.Default CSS variable applied
+		Assert.Contains("fill: var(--colorNeutralForeground1)", cut.Markup);
 	}
 
 	[Fact]

--- a/tests/Core/Samples/Icons.cs
+++ b/tests/Core/Samples/Icons.cs
@@ -12,6 +12,12 @@ public static class Icons
 
     public static readonly Icon PresenceAvailable = new Samples.PresenceAvailable();
 
+    /// <summary>Creates a fresh <c>Info</c> icon instance, avoiding mutation of the shared <see cref="Info"/> static.</summary>
+    public static Icon NewInfo() => new Samples.Info();
+
+    /// <summary>Creates a fresh <c>Warning</c> icon instance, avoiding mutation of the shared <see cref="Warning"/> static.</summary>
+    public static Icon NewWarning() => new Samples.Warning();
+
     internal class Samples
     {
         internal class Info : Icon { public Info() : base("Info", IconVariant.Filled, IconSize.Size24, "<path d=\"M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 8.25a1 1 0 0 0-1 .88v5.74a1 1 0 0 0 2 0v-5.62l-.01-.12a1 1 0 0 0-1-.88Zm0-3.75A1.25 1.25 0 1 0 12 9a1.25 1.25 0 0 0 0-2.5Z\"/>") { } }


### PR DESCRIPTION
You can now use `WithColor()` on `IconRest` and `IconActive` in both `FluentNavItem` and `FluentNavCategory`. Previously the icons always used `Color.Primary`/`Color.Default`

Example has been updated to use this new functionality. Unit test have been added to verify the new behavior.

Fix #4704 