### PR TITLE
[dev-v5] Dialog/Drawer: Add FixedHeaderFooter feature to FluentDialogBody

### DIFF
--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/Dialog/FixedHeaderFooterDialog.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/Dialog/FixedHeaderFooterDialog.razor
@@ -1,0 +1,14 @@
+@inherits FluentDialogInstance
+
+<FluentDialogBody FixedHeaderFooter="true">
+    <!-- Long content -->
+    @string.Join("", SampleData.Text.LoremIpsum.Select(i => $"{i}{Environment.NewLine}"));
+</FluentDialogBody>
+
+@code
+{
+    protected override Task OnActionClickedAsync(bool primary)
+    {
+        return DialogInstance.CloseAsync(primary ? "Yes" : "No");
+    }
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/Dialog/FixedHeaderFooterDialog.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/Dialog/FixedHeaderFooterDialog.razor
@@ -1,12 +1,18 @@
 @inherits FluentDialogInstance
 
-<FluentDialogBody FixedHeaderFooter="true">
+<FluentDialogBody FixedHeaderFooter="@ParamFixedHeaderFooter">
     <!-- Long content -->
+    <div>
+        ParamFixedHeaderFooter: @ParamFixedHeaderFooter
+    </div>
     @string.Join("", SampleData.Text.LoremIpsum.Select(i => $"{i}{Environment.NewLine}"));
 </FluentDialogBody>
 
 @code
 {
+    [Parameter]
+    public bool ParamFixedHeaderFooter { get; set; }
+
     protected override Task OnActionClickedAsync(bool primary)
     {
         return DialogInstance.CloseAsync(primary ? "Yes" : "No");

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogFixedHeaderFooterDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogFixedHeaderFooterDefault.razor
@@ -1,16 +1,19 @@
 @inject IDialogService DialogService
 
-<FluentStack>
-    <FluentButton OnClick="@(async e => await DialogService.ShowDialogAsync<Dialog.FixedHeaderFooterDialog>(DefaultOptions))">
+<FluentStack HorizontalGap="24px"
+             Wrap="true">
+    <FluentButton
+        OnClick="@(async e => await DialogService.ShowDialogAsync<Dialog.FixedHeaderFooterDialog>(DefaultOptions))">
         Open Dialog
     </FluentButton>
 
-    <FluentButton OnClick="@(async e => await DialogService.ShowDrawerAsync<Dialog.FixedHeaderFooterDialog>(DefaultOptions))">
+    <FluentButton
+        OnClick="@(async e => await DialogService.ShowDrawerAsync<Dialog.FixedHeaderFooterDialog>(DefaultOptions))">
         Open Drawer
     </FluentButton>
 </FluentStack>
 
-@code 
+@code
 {
     Action<DialogOptions> DefaultOptions => options =>
     {

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogFixedHeaderFooterDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogFixedHeaderFooterDefault.razor
@@ -1,0 +1,19 @@
+@inject IDialogService DialogService
+
+<FluentStack>
+    <FluentButton OnClick="@(async e => await DialogService.ShowDialogAsync<Dialog.FixedHeaderFooterDialog>(DefaultOptions))">
+        Open Dialog
+    </FluentButton>
+
+    <FluentButton OnClick="@(async e => await DialogService.ShowDrawerAsync<Dialog.FixedHeaderFooterDialog>(DefaultOptions))">
+        Open Drawer
+    </FluentButton>
+</FluentStack>
+
+@code 
+{
+    Action<DialogOptions> DefaultOptions => options =>
+    {
+        options.Header.Title = "Fixed Header and Footer Dialog";
+    };
+}

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogFixedHeaderFooterDefault.razor
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/Examples/DialogFixedHeaderFooterDefault.razor
@@ -2,6 +2,10 @@
 
 <FluentStack HorizontalGap="24px"
              Wrap="true">
+
+    <FluentSwitch Label="Fixed Header and Footer"
+                  @bind-Value="@IsFixedHeaderFooter" />
+
     <FluentButton
         OnClick="@(async e => await DialogService.ShowDialogAsync<Dialog.FixedHeaderFooterDialog>(DefaultOptions))">
         Open Dialog
@@ -15,8 +19,11 @@
 
 @code
 {
+    bool IsFixedHeaderFooter { get; set; } = true;
+
     Action<DialogOptions> DefaultOptions => options =>
     {
+        options.Parameters.Add("ParamFixedHeaderFooter", IsFixedHeaderFooter);
         options.Header.Title = "Fixed Header and Footer Dialog";
     };
 }

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
@@ -161,6 +161,25 @@ var result = await DialogService.ShowDialogAsync<CustomizedDialog>(options =>
 
 {{ DialogServiceCustomized Files=Code:DialogServiceCustomized.razor;CustomizedDialog:CustomizedDialog.razor;PersonDetails:PersonDetails.cs }}
 
+## FixedHeaderFooter
+
+By default, a `FluentDialogBody` (and its drawer variant) scrolls as a single block when its content
+overflows. This means the **title** and the **action buttons** (OK / Cancel) scroll away together with
+the content, which is usually not what you want for long forms, long lists, or large drawers.
+
+Setting `<FluentDialogBody FixedHeaderFooter="true">` changes the layout so that:
+
+ - The **header** and the **footer** (`ActionTemplate`) stay pinned at the top/bottom.
+ - Only the **content** (`ChildContent`) scrolls when it overflows.
+
+**When to use it**
+
+ - The dialog/drawer content may exceed the available height (long forms, lists, logs, terms of service, etc.).
+ - The primary actions must remain visible and reachable at all times, without forcing the user to scroll to the bottom.
+ - You want the title to stay visible as context while the user browses the content.
+
+{{ DialogFixedHeaderFooterDefault Files=Code:DialogFixedHeaderFooterDefault.razor;Dialog:FixedHeaderFooterDialog.razor }}
+
 ## Data exchange between components
 
 🔹You can easily send data from your main component to the dialog box

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/Components/Dialog/FluentDialog.md
@@ -161,7 +161,7 @@ var result = await DialogService.ShowDialogAsync<CustomizedDialog>(options =>
 
 {{ DialogServiceCustomized Files=Code:DialogServiceCustomized.razor;CustomizedDialog:CustomizedDialog.razor;PersonDetails:PersonDetails.cs }}
 
-## FixedHeaderFooter
+## Fixed Header and Footer
 
 By default, a `FluentDialogBody` (and its drawer variant) scrolls as a single block when its content
 overflows. This means the **title** and the **action buttons** (OK / Cancel) scroll away together with

--- a/src/Core/Components/Dialog/FluentDialogBody.razor
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor
@@ -7,7 +7,7 @@
         style="@StyleValue"
         class="@ClassValue"
         id="@Id"
-        fixedHeaderFooter="@FixedHeaderFooter"
+        fixed-header-footer="@FixedHeaderFooter"
         @attributes="@AdditionalAttributes">
 
     @* Header Title *@

--- a/src/Core/Components/Dialog/FluentDialogBody.razor
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor
@@ -7,6 +7,7 @@
         style="@StyleValue"
         class="@ClassValue"
         id="@Id"
+        fixedHeaderFooter="@FixedHeaderFooter"
         @attributes="@AdditionalAttributes">
 
     @* Header Title *@

--- a/src/Core/Components/Dialog/FluentDialogBody.razor
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor
@@ -7,7 +7,7 @@
         style="@StyleValue"
         class="@ClassValue"
         id="@Id"
-        fixed-header-footer="@FixedHeaderFooter"
+        scrollable="@(FixedHeaderFooter ? null : "true")"
         @attributes="@AdditionalAttributes">
 
     @* Header Title *@

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.cs
@@ -51,6 +51,13 @@ public partial class FluentDialogBody : FluentComponentBase
     [Parameter]
     public RenderFragment? ActionTemplate { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the header and footer are fixed.
+    /// Only the content will scroll when the content overflows.
+    /// </summary>
+    [Parameter]
+    public bool FixedHeaderFooter { get; set; }
+
     /// <summary />
     internal async Task ActionClickHandlerAsync(DialogOptionsFooterAction item)
     {

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.cs
@@ -54,9 +54,10 @@ public partial class FluentDialogBody : FluentComponentBase
     /// <summary>
     /// Gets or sets a value indicating whether the header and footer are fixed.
     /// Only the content will scroll when the content overflows.
+    /// Default is true.
     /// </summary>
     [Parameter]
-    public bool FixedHeaderFooter { get; set; }
+    public bool FixedHeaderFooter { get; set; } = true;
 
     /// <summary />
     internal async Task ActionClickHandlerAsync(DialogOptionsFooterAction item)

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.css
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.css
@@ -3,85 +3,85 @@
     But we need to duplicated because the "action" and "footer" slots are a single `div` containing the buttons.
 */
 
-/* Dialog -> fixed-header-footer = true */
-fluent-dialog[fuib] fluent-dialog-body[fuib][fixed-header-footer] {
+/* Dialog -> scrollable = false */
+fluent-dialog[fuib] fluent-dialog-body[fuib]:not([scrollable]) {
   grid-template-rows: auto 1fr auto;
   height: 100%;
 }
 
-fluent-dialog[fuib] fluent-dialog-body[fuib][fixed-header-footer]>div[slot="action"] {
+fluent-dialog[fuib] fluent-dialog-body[fuib]:not([scrollable])>div[slot="action"] {
   display: flex;
   gap: var(--spacingVerticalS);
   flex-direction: row;
 }
 
-/* Dialog -> fixed-header-footer = false */
-fluent-dialog[fuib] fluent-dialog-body[fuib]:not([fixed-header-footer]) {
+/* Dialog -> scrollable = true */
+fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable] {
   grid-template-rows: min-content minmax(0, 1fr) min-content;
   padding: 0;
   overflow: hidden;
   height: 100%;
 }
 
-fluent-dialog[fuib] fluent-dialog-body[fuib]:not([fixed-header-footer])::part(title) {
+fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable]::part(title) {
   padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
-fluent-dialog[fuib] fluent-dialog-body[fuib]:not([fixed-header-footer])::part(content) {
+fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable]::part(content) {
   overflow: auto;
   padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
-fluent-dialog[fuib] fluent-dialog-body[fuib]:not([fixed-header-footer])::part(actions) {
+fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable]::part(actions) {
   padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
-fluent-dialog[fuib] fluent-dialog-body[fuib]:not([fixed-header-footer])>div[slot="action"] {
+fluent-dialog[fuib] fluent-dialog-body[fuib][scrollable]>div[slot="action"] {
   display: flex;
   gap: var(--spacingVerticalS);
   flex-direction: row;
 }
 
-/* Drawer -> fixed-header-footer = true */
-fluent-drawer[fuib] fluent-drawer-body[fuib][fixed-header-footer] {
+/* Drawer -> scrollable = false */
+fluent-drawer[fuib] fluent-drawer-body[fuib]:not([scrollable]) {
   grid-template-rows: min-content minmax(0, 1fr) min-content;
   padding: 0;
   overflow: hidden;
   width: var(--drawer-width, 100%);
 }
 
-fluent-drawer[fuib] fluent-drawer-body[fuib][fixed-header-footer]::part(header) {
+fluent-drawer[fuib] fluent-drawer-body[fuib]:not([scrollable])::part(header) {
   padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
-fluent-drawer[fuib] fluent-drawer-body[fuib][fixed-header-footer]::part(content) {
+fluent-drawer[fuib] fluent-drawer-body[fuib]:not([scrollable])::part(content) {
   overflow: auto;
   padding: 0 var(--spacingHorizontalXL);
 }
 
-fluent-drawer[fuib] fluent-drawer-body[fuib][fixed-header-footer]::part(footer) {
+fluent-drawer[fuib] fluent-drawer-body[fuib]:not([scrollable])::part(footer) {
   padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
-fluent-drawer[fuib] fluent-drawer-body[fuib][fixed-header-footer]>div[slot="footer"] {
+fluent-drawer[fuib] fluent-drawer-body[fuib]:not([scrollable])>div[slot="footer"] {
   display: flex;
   justify-content: flex-start;
   gap: var(--spacingHorizontalM);
   width: 100%;
 }
 
-/* Drawer -> fixed-header-footer = false */
+/* Drawer -> scrollable = true */
 
-fluent-drawer[fuib] fluent-drawer-body[fuib]:not([fixed-header-footer])::part(content) {
+fluent-drawer[fuib] fluent-drawer-body[fuib][scrollable]::part(content) {
     padding: var(--spacingVerticalXL) 0;
 }
 
-fluent-drawer[fuib] fluent-drawer-body[fuib]:not([fixed-header-footer]) {
+fluent-drawer[fuib] fluent-drawer-body[fuib][scrollable] {
   overflow-y: auto;
   width: var(--drawer-width, 100%);
 }
 
-fluent-drawer[fuib] fluent-drawer-body[fuib]:not([fixed-header-footer])>div[slot="footer"] {
+fluent-drawer[fuib] fluent-drawer-body[fuib][scrollable]>div[slot="footer"] {
   display: flex;
   justify-content: flex-start;
   gap: var(--spacingHorizontalM);

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.css
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.css
@@ -5,8 +5,23 @@
 
 /* Desktop and Mobile */
 fluent-dialog[fuib] fluent-dialog-body[fuib] {
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: min-content minmax(0, 1fr) min-content;
+  padding: 0;
+  overflow: hidden;
   height: 100%;
+}
+
+fluent-dialog[fuib] fluent-dialog-body[fuib]::part(title) {
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+}
+
+fluent-dialog[fuib] fluent-dialog-body[fuib]::part(content) {
+  overflow: auto;
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+}
+
+fluent-dialog[fuib] fluent-dialog-body[fuib]::part(actions) {
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
 fluent-dialog-body[fuib]>div[slot="action"] {
@@ -16,54 +31,30 @@ fluent-dialog-body[fuib]>div[slot="action"] {
 }
 
 fluent-drawer[fuib] fluent-drawer-body[fuib] {
-  overflow-y: auto;
+  grid-template-rows: min-content minmax(0, 1fr) min-content;
+  padding: 0;
+  overflow: hidden;
   width: var(--drawer-width, 100%);
 }
 
-fluent-drawer-body[fuib]>div[slot="footer"] {
+fluent-drawer[fuib] fluent-drawer-body[fuib]::part(header) {
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+}
+
+fluent-drawer[fuib] fluent-drawer-body[fuib]::part(content) {
+  overflow: auto;
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+}
+
+fluent-drawer[fuib] fluent-drawer-body[fuib]::part(footer) {
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+}
+
+fluent-drawer[fuib] fluent-drawer-body[fuib]>div[slot="footer"] {
   display: flex;
   justify-content: flex-start;
   gap: var(--spacingHorizontalM);
   width: 100%;
-}
-
-/* fixedHeaderFooter */
-fluent-drawer-body[fuib][fixedHeaderFooter] {
-  grid-template-rows: min-content minmax(0, 1fr) min-content;
-  padding: 0;
-  overflow: hidden;
-}
-
-fluent-drawer-body[fuib][fixedHeaderFooter]::part(header) {
-  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
-}
-
-fluent-drawer-body[fuib][fixedHeaderFooter]::part(content) {
-  overflow: auto;
-  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
-}
-
-fluent-drawer-body[fuib][fixedHeaderFooter]::part(footer) {
-  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
-}
-
-fluent-dialog-body[fuib][fixedHeaderFooter] {
-  grid-template-rows: min-content minmax(0, 1fr) min-content;
-  padding: 0;
-  overflow: hidden;
-}
-
-fluent-dialog-body[fuib][fixedHeaderFooter]::part(title) {
-  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
-}
-
-fluent-dialog-body[fuib][fixedHeaderFooter]::part(content) {
-  overflow: auto;
-  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
-}
-
-fluent-dialog-body[fuib][fixedHeaderFooter]::part(actions) {
-  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
 /* Mobile */

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.css
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.css
@@ -9,33 +9,72 @@ fluent-dialog[fuib] fluent-dialog-body[fuib] {
   height: 100%;
 }
 
-  fluent-dialog-body[fuib] > div[slot="action"] {
-    display: flex;
-    gap: var(--spacingVerticalS);
-    flex-direction: row;
-  }
+fluent-dialog-body[fuib]>div[slot="action"] {
+  display: flex;
+  gap: var(--spacingVerticalS);
+  flex-direction: row;
+}
 
 fluent-drawer[fuib] fluent-drawer-body[fuib] {
   overflow-y: auto;
   width: var(--drawer-width, 100%);
 }
 
-fluent-drawer-body[fuib] > div[slot="footer"] {
+fluent-drawer-body[fuib]>div[slot="footer"] {
   display: flex;
   justify-content: flex-start;
   gap: var(--spacingHorizontalM);
   width: 100%;
 }
 
+/* fixedHeaderFooter */
+fluent-drawer-body[fuib][fixedHeaderFooter] {
+  grid-template-rows: min-content minmax(0, 1fr) min-content;
+  padding: 0;
+  overflow: hidden;
+}
+
+fluent-drawer-body[fuib][fixedHeaderFooter]::part(header) {
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+}
+
+fluent-drawer-body[fuib][fixedHeaderFooter]::part(content) {
+  overflow: auto;
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+}
+
+fluent-drawer-body[fuib][fixedHeaderFooter]::part(footer) {
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+}
+
+fluent-dialog-body[fuib][fixedHeaderFooter] {
+  grid-template-rows: min-content minmax(0, 1fr) min-content;
+  padding: 0;
+  overflow: hidden;
+}
+
+fluent-dialog-body[fuib][fixedHeaderFooter]::part(title) {
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+}
+
+fluent-dialog-body[fuib][fixedHeaderFooter]::part(content) {
+  overflow: auto;
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+}
+
+fluent-dialog-body[fuib][fixedHeaderFooter]::part(actions) {
+  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+}
+
 /* Mobile */
 @container (max-width: 479px) {
-  fluent-dialog-body[fuib] > div[slot="action"] {
+  fluent-dialog-body[fuib]>div[slot="action"] {
     flex-direction: column;
   }
 }
 
 @media (max-width: 600px) {
-  fluent-drawer-body[fuib] > div[slot="footer"] {
+  fluent-drawer-body[fuib]>div[slot="footer"] {
     flex-direction: column;
   }
 }

--- a/src/Core/Components/Dialog/FluentDialogBody.razor.css
+++ b/src/Core/Components/Dialog/FluentDialogBody.razor.css
@@ -3,54 +3,85 @@
     But we need to duplicated because the "action" and "footer" slots are a single `div` containing the buttons.
 */
 
-/* Desktop and Mobile */
-fluent-dialog[fuib] fluent-dialog-body[fuib] {
+/* Dialog -> fixed-header-footer = true */
+fluent-dialog[fuib] fluent-dialog-body[fuib][fixed-header-footer] {
+  grid-template-rows: auto 1fr auto;
+  height: 100%;
+}
+
+fluent-dialog[fuib] fluent-dialog-body[fuib][fixed-header-footer]>div[slot="action"] {
+  display: flex;
+  gap: var(--spacingVerticalS);
+  flex-direction: row;
+}
+
+/* Dialog -> fixed-header-footer = false */
+fluent-dialog[fuib] fluent-dialog-body[fuib]:not([fixed-header-footer]) {
   grid-template-rows: min-content minmax(0, 1fr) min-content;
   padding: 0;
   overflow: hidden;
   height: 100%;
 }
 
-fluent-dialog[fuib] fluent-dialog-body[fuib]::part(title) {
+fluent-dialog[fuib] fluent-dialog-body[fuib]:not([fixed-header-footer])::part(title) {
   padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
-fluent-dialog[fuib] fluent-dialog-body[fuib]::part(content) {
+fluent-dialog[fuib] fluent-dialog-body[fuib]:not([fixed-header-footer])::part(content) {
   overflow: auto;
   padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
-fluent-dialog[fuib] fluent-dialog-body[fuib]::part(actions) {
+fluent-dialog[fuib] fluent-dialog-body[fuib]:not([fixed-header-footer])::part(actions) {
   padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
-fluent-dialog-body[fuib]>div[slot="action"] {
+fluent-dialog[fuib] fluent-dialog-body[fuib]:not([fixed-header-footer])>div[slot="action"] {
   display: flex;
   gap: var(--spacingVerticalS);
   flex-direction: row;
 }
 
-fluent-drawer[fuib] fluent-drawer-body[fuib] {
+/* Drawer -> fixed-header-footer = true */
+fluent-drawer[fuib] fluent-drawer-body[fuib][fixed-header-footer] {
   grid-template-rows: min-content minmax(0, 1fr) min-content;
   padding: 0;
   overflow: hidden;
   width: var(--drawer-width, 100%);
 }
 
-fluent-drawer[fuib] fluent-drawer-body[fuib]::part(header) {
+fluent-drawer[fuib] fluent-drawer-body[fuib][fixed-header-footer]::part(header) {
   padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
-fluent-drawer[fuib] fluent-drawer-body[fuib]::part(content) {
+fluent-drawer[fuib] fluent-drawer-body[fuib][fixed-header-footer]::part(content) {
   overflow: auto;
+  padding: 0 var(--spacingHorizontalXL);
+}
+
+fluent-drawer[fuib] fluent-drawer-body[fuib][fixed-header-footer]::part(footer) {
   padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
 }
 
-fluent-drawer[fuib] fluent-drawer-body[fuib]::part(footer) {
-  padding: var(--spacingVerticalXL) var(--spacingHorizontalXL);
+fluent-drawer[fuib] fluent-drawer-body[fuib][fixed-header-footer]>div[slot="footer"] {
+  display: flex;
+  justify-content: flex-start;
+  gap: var(--spacingHorizontalM);
+  width: 100%;
 }
 
-fluent-drawer[fuib] fluent-drawer-body[fuib]>div[slot="footer"] {
+/* Drawer -> fixed-header-footer = false */
+
+fluent-drawer[fuib] fluent-drawer-body[fuib]:not([fixed-header-footer])::part(content) {
+    padding: var(--spacingVerticalXL) 0;
+}
+
+fluent-drawer[fuib] fluent-drawer-body[fuib]:not([fixed-header-footer]) {
+  overflow-y: auto;
+  width: var(--drawer-width, 100%);
+}
+
+fluent-drawer[fuib] fluent-drawer-body[fuib]:not([fixed-header-footer])>div[slot="footer"] {
   display: flex;
   justify-content: flex-start;
   gap: var(--spacingHorizontalM);

--- a/tests/Core/Components/Dialog/FluentDialogBodyTests.razor
+++ b/tests/Core/Components/Dialog/FluentDialogBodyTests.razor
@@ -83,4 +83,24 @@
             Assert.True(buttonClicked);
         }
     }
+
+    [Fact]
+    public void FluentDialogBody_FixedHeaderFooter_False()
+    {
+        var cut = Render(@<FluentDialogBody FixedHeaderFooter="false"></FluentDialogBody>);
+
+        // Assert
+        var body = cut.Find("fluent-dialog-body");
+        Assert.True(body.HasAttribute("scrollable"));
+    }
+
+    [Fact]
+    public void FluentDialogBody_FixedHeaderFooter_True()
+    {
+        var cut = Render(@<FluentDialogBody FixedHeaderFooter="true"></FluentDialogBody>);
+
+        // Assert
+        var body = cut.Find("fluent-dialog-body");
+        Assert.False(body.HasAttribute("scrollable"));
+    }
 }


### PR DESCRIPTION
# [dev-v5] Dialog/Drawer: Add `FixedHeaderFooter` feature to `FluentDialogBody`

Introduce a `FixedHeaderFooter `feature in **FluentDialogBody** to enhance user experience by keeping the header and footer visible while scrolling through content. 

Update documentation and examples accordingly, and include tests to ensure expected behavior. This change improves usability for long forms and lists within dialogs.

Default value is `true`

```razor
<FluentDialogBody FixedHeaderFooter="true">
   ...
</FluentDialogBody>
```

https://github.com/user-attachments/assets/bd0996f4-5dcf-42fd-a756-60b21983ec37

## Unit Tests

Updated