### PR TITLE
[dev-v5] Add CSS to hide fluent-menu-list when not in popover

### DIFF
--- a/src/Core/Components/Menu/FluentMenuList.razor.css
+++ b/src/Core/Components/Menu/FluentMenuList.razor.css
@@ -1,0 +1,4 @@
+/* Fix #4744 */
+fluent-menu fluent-menu-list:not([popover]) {
+    display: none;
+}


### PR DESCRIPTION
# [dev-v5] Add CSS to hide fluent-menu-list when not in popover

Implement CSS to ensure the `fluent-menu-list` is hidden when not displayed in a popover, addressing issue #4744. 
This change improves the user interface by preventing unnecessary visibility of the menu list.

Before

https://github.com/user-attachments/assets/f6fafa8b-de61-4c1f-8fa7-08f2c1fc89eb


After


https://github.com/user-attachments/assets/77dd3a75-1e15-44e8-8106-2790c7469e4f


## Unit Tests

No changes