### PR TITLE
[dev-v5] Add note about daily updates and link to setup instructions

### DIFF
--- a/docs/using-latest-daily.md
+++ b/docs/using-latest-daily.md
@@ -24,6 +24,30 @@ or else in the global NuGet.config. See [configuring NuGet behavior](https://lea
 Alternatively, if you are using Visual Studio, you can [Install and manage packages in Visual Studio](https://learn.microsoft.com/nuget/consume-packages/install-use-packages-visual-studio#package-sources)
 and add the feed `https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json` there.
 
+Example `nuget.config` file (adapt to your environment):
+```json
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="preview" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+  </packageSources>
+
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+      <package pattern="Microsoft.FluentUI.AspNetCore.Components.Emoji" />
+      <package pattern="Microsoft.FluentUI.AspNetCore.Components.Icons" />
+    </packageSource>
+
+    <packageSource key="preview">
+      <package pattern="Microsoft.FluentUI.AspNetCore.Components" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>
+```
+
 ## Restore error
 
 If you get the error **NU3018** `The author primary signature's signing certificate is not trusted by the trust provider`

--- a/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Installation.md
+++ b/examples/Demo/FluentUI.Demo.Client/Documentation/GetStarted/Installation.md
@@ -36,6 +36,9 @@ dotnet add package Microsoft.FluentUI.AspNetCore.Components.Icons
 
 **Note** With the pre-release version, make sure you don't have the configuration `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` in your csproj file.
 
+> [!NOTE] If you'd like to take advantage of the daily updates, please follow [these steps](https://github.com/microsoft/fluentui-blazor/blob/dev-v5/docs/using-latest-daily.md).
+> Be aware, however, that this is at your own risk: daily builds may introduce new bugs or breaking changes while you are working.
+
 ### 2. Add Imports
 
 In your `_Imports.razor` file, include:


### PR DESCRIPTION
# [dev-v5] Add note about daily updates and link to setup instructions

Include a note regarding daily updates and provide a link to setup instructions for users. This change aims to inform users about the potential risks associated with using daily builds.

