### PR TITLE
[dev-v5] Dialog - Fixes the issue where pressing the Esc key would immediately bring up another dialog box

### DIFF
--- a/src/Core/Components/Dialog/FluentDialog.razor.cs
+++ b/src/Core/Components/Dialog/FluentDialog.razor.cs
@@ -16,6 +16,8 @@ namespace Microsoft.FluentUI.AspNetCore.Components;
 /// </summary>
 public partial class FluentDialog : FluentComponentBase
 {
+    private string? _shownInstanceId;
+
     /// <summary />
     [DynamicDependency(nameof(OnToggleAsync))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(DialogToggleEventArgs))]
@@ -78,8 +80,10 @@ public partial class FluentDialog : FluentComponentBase
     /// <summary />
     protected override Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender && LaunchedFromService)
+        var shouldShowDialog = string.CompareOrdinal(_shownInstanceId, Instance?.Id) != 0;
+        if (shouldShowDialog && LaunchedFromService)
         {
+            _shownInstanceId = Instance?.Id;
             var instance = Instance as DialogInstance;
             if (instance is not null)
             {


### PR DESCRIPTION

Improve dialog instance tracking to avoid unnecessary re-renders by ensuring the dialog only shows when the instance ID changes. 

This fixes the issue where the ESC key did not close the provider dialog.

- Using a button to cancel
   ```
   Dialog.CancelAsync() 
      => RemoveDialogFromProviderAsync(dialog) 
         => ShowInfoAsync("Hello") 
            => Dialog.OnAfterRenderAsync(firstRender = true) ✅
   ```

- Using the ESC to cancel
   The new Dialog.OnAfterRenderAsync contains always `firstRender = false` => `ShowAsync()` is not called.
   So, the dialog is in the Provider but not visible in the UI.
   ```
   Dialog.OnToggleAsync() 
      => ShowInfoAsync("Hello") 
         => RemoveDialogFromProviderAsync(dialog) 
            => Dialog.OnAfterRenderAsync(firstRender = false) ❌
   ```

Fix #4752