### PR TITLE
[dev-v5][MessageBar] Remove not working CSS rule

### DIFF
--- a/src/Core/Components/MessageBar/FluentMessageBar.razor.css
+++ b/src/Core/Components/MessageBar/FluentMessageBar.razor.css
@@ -22,10 +22,6 @@ fluent-message-bar .title {
   padding: 0 4px 0 0;
 }
 
-fluent-message-bar .content {
-  max-width: unset;
-}
-
 fluent-message-bar .actions {
   display: flex;
   column-gap: var(--spacingHorizontalM);


### PR DESCRIPTION
# Pull Request

## 📖 Description

This removes a small potion of CSS from `FluentMessageBar` which is not working. it was supposed to grow the message .content from the hardcoded 520px to max block size but this rule will always be ignored. So I removed it to shrink down the file size a bit.


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fluentui-blazor/blob/master/docs/contributing.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have added [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for my new component
- [x] I have modified an existing component
- [x] I have validated the [Unit Tests](https://github.com/Microsoft/fluentui-blazor/blob/master/unit-tests.md) for an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
