### PR TITLE
[dev-v5] docs(tab): Clarify Header vs HeaderTemplate XML documentation on FluentTab

### DIFF
--- a/src/Core/Components/Tabs/FluentTab.razor.cs
+++ b/src/Core/Components/Tabs/FluentTab.razor.cs
@@ -41,14 +41,23 @@ public partial class FluentTab : FluentComponentBase, ITooltipComponent
     public bool Disabled { get; set; }
 
     /// <summary>
-    /// Gets or sets the label of the tab.
+    /// Gets or sets the text displayed on the tab.
+    /// This is the plain-text label shown in the tab strip (e.g., <c>Header="My Tab"</c>).
+    /// For rich content (icons, custom markup), use <see cref="HeaderTemplate"/> instead.
     /// </summary>
+    /// <remarks>
+    /// Renamed from <c>Label</c> in v4.
+    /// </remarks>
     [Parameter]
     public string? Header { get; set; }
 
     /// <summary>
-    /// Gets or sets the header content of the tab.
+    /// Gets or sets the custom header content of the tab (supports icons and rich markup).
+    /// Use this instead of <see cref="Header"/> when you need more than plain text.
     /// </summary>
+    /// <remarks>
+    /// Renamed from <c>Header</c> in v4.
+    /// </remarks>
     [Parameter]
     public RenderFragment? HeaderTemplate { get; set; }
 


### PR DESCRIPTION
## Problem

AI agents (GitHub Copilot, etc.) consistently generate `Text="..."` instead of `Header="..."` when scaffolding `FluentTab` components. This is because:

1. The previous XML doc for `Header` said only `"Gets or sets the label of the tab."` — the word **"label"** leads models to look for a `Label` property (the v4 name), and when that is absent they fall back to `Text`, which is the convention used by other Blazor UI frameworks (Telerik, MudBlazor, …).
2. The name `Header` naturally evokes rich/template content rather than a plain string, reinforcing the confusion with `HeaderTemplate`.
3. Nothing in the XML docs linked the two sibling parameters together or explained which to use in each situation.

## Change

Improved the XML doc summaries for both parameters on `FluentTab.razor.cs`:

### `Header` (plain-text string)
```xml
/// <summary>
/// Gets or sets the text displayed on the tab.
/// This is the plain-text label shown in the tab strip (e.g., <c>Header="My Tab"</c>).
/// For rich content (icons, custom markup), use <see cref="HeaderTemplate"/> instead.
/// </summary>
/// <remarks>
/// Renamed from <c>Label</c> in v4.
/// </remarks>
```

### `HeaderTemplate` (rich RenderFragment)
```xml
/// <summary>
/// Gets or sets the custom header content of the tab (supports icons and rich markup).
/// Use this instead of <see cref="Header"/> when you need more than plain text.
/// </summary>
/// <remarks>
/// Renamed from <c>Header</c> in v4.
/// </remarks>
```

## Why this matters for AI agents

These doc summaries are extracted at build time into `FluentUIComponentsDocumentation.json` and served by the **Fluent UI Blazor MCP server**. Clearer descriptions with a concrete usage example (`Header="My Tab"`) and an explicit cross-reference between the two properties give models the signal they need to pick the right one without hallucinating `Text`.

## Files changed

- `src/Core/Components/Tabs/FluentTab.razor.cs`